### PR TITLE
CI workflows for building, formatting, and sca

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,69 @@
+name: Build and Test
+
+on:
+  push:
+    branches: [ "main", "development" ]
+  pull_request:
+    branches: [ "main", "development" ]
+
+jobs:
+  build:
+    name: ${{ matrix.os }} - ${{ matrix.build_type }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # Linux: Debug Build
+          - os: ubuntu-latest
+            build_type: Debug
+
+          # Linux: Release Build
+          - os: ubuntu-latest
+            build_type: Release
+
+          # Windows: Release Only
+          - os: windows-latest
+            build_type: Release
+
+          # macOS: Release Only
+          - os: macos-latest
+            build_type: Release
+
+    steps:
+    - uses: actions/checkout@v4
+      if: matrix.os == 'ubuntu-latest' || github.ref != 'refs/heads/development'
+      with:
+        submodules: recursive
+
+    - name: Configure CMake
+      if: matrix.os == 'ubuntu-latest' || github.ref != 'refs/heads/development'
+      run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{matrix.build_type}}
+
+    - name: Build
+      if: matrix.os == 'ubuntu-latest' || github.ref != 'refs/heads/development'
+      run: cmake --build ${{github.workspace}}/build --config ${{matrix.build_type}}
+
+    - name: Test
+      if: matrix.os == 'ubuntu-latest'
+      working-directory: ${{github.workspace}}/build
+      run: ctest -C ${{matrix.build_type}} --output-on-failure --output-junit test_results.xml
+
+    - name: Upload Test Results
+      if: matrix.os == 'ubuntu-latest' && always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: test-results-${{ matrix.os }}-${{ matrix.build_type }}
+        path: ${{github.workspace}}/build/test_results.xml
+
+    - name: Upload Build Artifacts
+      if: (matrix.os == 'ubuntu-latest' || github.ref != 'refs/heads/development') && success()
+      uses: actions/upload-artifact@v4
+      with:
+        name: build-artifacts-${{ matrix.os }}-${{ matrix.build_type }}
+        path: |
+          ${{github.workspace}}/build/**/EnigmaMachineCore*
+          !${{github.workspace}}/build/**/*.o
+          !${{github.workspace}}/build/**/*.obj
+          !${{github.workspace}}/build/**/*.tlog
+          !${{github.workspace}}/build/**/*.log

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,32 +32,32 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-      if: matrix.os == 'ubuntu-latest' || github.ref != 'refs/heads/development'
+      if: matrix.os == 'ubuntu-latest' || (github.ref != 'refs/heads/development' && github.base_ref != 'development')
       with:
         submodules: recursive
 
     - name: Configure CMake
-      if: matrix.os == 'ubuntu-latest' || github.ref != 'refs/heads/development'
+      if: matrix.os == 'ubuntu-latest' || (github.ref != 'refs/heads/development' && github.base_ref != 'development')
       run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{matrix.build_type}}
 
     - name: Build
-      if: matrix.os == 'ubuntu-latest' || github.ref != 'refs/heads/development'
+      if: matrix.os == 'ubuntu-latest' || (github.ref != 'refs/heads/development' && github.base_ref != 'development')
       run: cmake --build ${{github.workspace}}/build --config ${{matrix.build_type}}
 
     - name: Test
-      if: matrix.os == 'ubuntu-latest'
+      if: matrix.os == 'ubuntu-latest' || (github.ref != 'refs/heads/development' && github.base_ref != 'development')
       working-directory: ${{github.workspace}}/build
       run: ctest -C ${{matrix.build_type}} --output-on-failure --output-junit test_results.xml
 
     - name: Upload Test Results
-      if: matrix.os == 'ubuntu-latest' && always()
+      if: (matrix.os == 'ubuntu-latest' || (github.ref != 'refs/heads/development' && github.base_ref != 'development')) && always()
       uses: actions/upload-artifact@v4
       with:
         name: test-results-${{ matrix.os }}-${{ matrix.build_type }}
         path: ${{github.workspace}}/build/test_results.xml
 
     - name: Upload Build Artifacts
-      if: (matrix.os == 'ubuntu-latest' || github.ref != 'refs/heads/development') && success()
+      if: (matrix.os == 'ubuntu-latest' || (github.ref != 'refs/heads/development' && github.base_ref != 'development')) && success()
       uses: actions/upload-artifact@v4
       with:
         name: build-artifacts-${{ matrix.os }}-${{ matrix.build_type }}

--- a/.github/workflows/format-check.yml
+++ b/.github/workflows/format-check.yml
@@ -1,0 +1,38 @@
+name: Clang-Format Check
+
+on:
+  pull_request:
+    branches: [ "main", "development" ]
+
+jobs:
+  format-check:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Install clang-format
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y clang-format
+
+    - name: Run clang-format
+      run: |
+        # Find all source files excluding external/ and build/
+        # Matches the patterns in CMakeLists.txt
+        find EnigmaMachine PlugBoard RotorBox config tests -name '*.cpp' -o -name '*.hpp' | xargs clang-format -i -style=file
+        clang-format -i -style=file main.cpp
+
+    - name: Check for changes
+      run: |
+        if ! git diff --exit-code; then
+          git diff > format_fixes.patch
+          exit 1
+        fi
+
+    - name: Upload Format Patch
+      if: failure()
+      uses: actions/upload-artifact@v4
+      with:
+        name: format-fixes
+        path: format_fixes.patch

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -1,0 +1,36 @@
+name: Static Analysis
+
+on:
+  push:
+    branches: [ "main", "development" ]
+  pull_request:
+    branches: [ "main", "development" ]
+
+jobs:
+  clang-tidy:
+    name: Clang-Tidy Analysis
+    runs-on: ubuntu-latest
+    
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        submodules: recursive
+
+    - name: Install dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y clang-tidy
+
+    - name: Configure CMake
+      run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=Debug -DENABLE_CLANG_TIDY=ON
+
+    - name: Run Analysis
+      # Building the target triggers clang-tidy as configured in CMakeLists.txt
+      run: cmake --build ${{github.workspace}}/build 2>&1 | tee static-analysis.log
+
+    - name: Upload Analysis Log
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: static-analysis-log
+        path: static-analysis.log


### PR DESCRIPTION
Creating CI workflows in github actions for building the project, checking code format, and performing static analysis. 

- Build runs on push and pull request events targeting the main and development branches. On main runes on ubuntu-latest, windows-latest, and macos-latest. On development runs on ubuntu-latest. 
- Clang-format is used for format checking, runs on ubuntu-latest. 
- Static analysis is performed using Clang-tidy, runs on ubuntu-latest.