### PR TITLE
Correctly deduce iterator type

### DIFF
--- a/RotorBox/Transformer/Rotor/src/Rotor.cpp
+++ b/RotorBox/Transformer/Rotor/src/Rotor.cpp
@@ -47,8 +47,8 @@ void Rotor::initReverseTransformLUT() {
     const auto& forwardRow = getTransformRow(0);
 
     for (int forwardValue = 0; forwardValue < TRANSFORMER_SIZE; forwardValue++) {
-        const auto* it = std::find_if(forwardRow.begin(), forwardRow.end(),
-                                      [forwardValue](int value) { return value == forwardValue; });
+        const auto it = std::find_if(forwardRow.begin(), forwardRow.end(),
+                                     [forwardValue](int value) { return value == forwardValue; });
 
         if (it != forwardRow.end()) {
             int reverseIndex = std::distance(forwardRow.begin(), it);


### PR DESCRIPTION
what:
- Replaced 'const auto* it' with 'const auto it' when capturing the result of std::find_if in the 'initReverseTransformLUT' function.

Why:
- 'std::find_if' returns an iterator, which is not guaranteed to be a raw pointer across all platforms (e.g., MSVC on Windows). Using 'auto' ensures portable and correct type deduction for the iterator.