### PR TITLE
Add string header to PlugBoard.cpp

### DIFF
--- a/PlugBoard/src/PlugBoard.cpp
+++ b/PlugBoard/src/PlugBoard.cpp
@@ -6,6 +6,7 @@
 #include "PlugBoard.hpp"
 #include <iostream>
 #include <stdexcept>
+#include <string>
 #include "config.hpp"
 
 PlugBoard::PlugBoard() {

--- a/RotorBox/Transformer/Rotor/src/Rotor.cpp
+++ b/RotorBox/Transformer/Rotor/src/Rotor.cpp
@@ -47,8 +47,8 @@ void Rotor::initReverseTransformLUT() {
     const auto& forwardRow = getTransformRow(0);
 
     for (int forwardValue = 0; forwardValue < TRANSFORMER_SIZE; forwardValue++) {
-        const auto* it = std::find_if(forwardRow.begin(), forwardRow.end(),
-                                      [forwardValue](int value) { return value == forwardValue; });
+        const auto it = std::find_if(forwardRow.begin(), forwardRow.end(),
+                                     [forwardValue](int value) { return value == forwardValue; });
 
         if (it != forwardRow.end()) {
             int reverseIndex = std::distance(forwardRow.begin(), it);


### PR DESCRIPTION
Add string header to PlugBoard.cpp
Added missing include for string header in PlugBoard.cpp to resolve compilation issues on Windows.
Module PlugBoard uses std::string but did not include the necessary header, leading to build failures on certain platforms.