### PR TITLE
Configure Doxygen with architecture diagrams and Deployment to GH Pages

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -1,0 +1,68 @@
+name: Documentation
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  build-docs:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Install Dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y doxygen graphviz plantuml
+
+      - name: Setup Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+
+      - name: Configure CMake
+        # We need to configure the project to generate the 'doxygen' target
+        run: cmake -B build
+
+      - name: Build Documentation
+        # This target depends on 'generate_diagrams', so it will:
+        # 1. Generate SVG diagrams from PlantUML files
+        # 2. Run Doxygen to generate the HTML site
+        run: cmake --build build --target doxygen
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          # Points to the directory where Doxygen output the HTML files
+          # Based on Doxyfile.in: OUTPUT_DIRECTORY + HTML_OUTPUT
+          path: 'docs/doxygen-gen-files/html'
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build-docs
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -35,5 +35,6 @@
 build/*
 !build/
 
-# Documentation (Generated)
+# Documentation
 docs/doxygen-gen-files/
+docs/diagrams/output/

--- a/Doxyfile.in
+++ b/Doxyfile.in
@@ -31,6 +31,7 @@ WARN_NO_PARAMDOC       = YES
 
 # Input files configuration
 INPUT                  = README.md \
+                         ./docs \
                          ./EnigmaMachine \
                          ./RotorBox \
                          ./PlugBoard \
@@ -40,6 +41,7 @@ RECURSIVE              = YES
 EXCLUDE                = build/ external/ .git/
 EXCLUDE_PATTERNS       = */.git/* */build/* */external/*
 USE_MDFILE_AS_MAINPAGE = README.md
+IMAGE_PATH             = docs/diagrams
 
 # Source browsing
 SOURCE_BROWSER         = YES
@@ -88,6 +90,6 @@ DIRECTORY_GRAPH        = YES
 
 # PlantUML
 PLANTUML_JAR_PATH      = @PLANTUML_PATH@
-PLANTUML_INCLUDE_PATH  = ./docs
+PLANTUML_INCLUDE_PATH  = @CMAKE_CURRENT_SOURCE_DIR@/docs/diagrams
 
 

--- a/cmake/Doc.cmake
+++ b/cmake/Doc.cmake
@@ -1,11 +1,40 @@
 # Generation of Documentation
 find_package(Doxygen)
-find_program(PLANTUML_PATH NAMES plantuml plantuml.jar PATHS /usr/bin /usr/share/plantuml /usr/local/bin)
+find_package(Java REQUIRED)
+
+# Look for the JAR file specifically because Doxygen expects to run it with 'java -jar'
+find_file(PLANTUML_PATH 
+    NAMES plantuml.jar 
+    PATHS 
+    /usr/share/java/plantuml
+    /usr/share/plantuml
+    /usr/local/share/plantuml
+    /usr/local/bin
+    /opt/plantuml
+    DOC "Path to plantuml.jar"
+)
 
 if (PLANTUML_PATH)
-    message(STATUS "Found PlantUML: ${PLANTUML_PATH}")
+    message(STATUS "Found PlantUML JAR: ${PLANTUML_PATH}")
+
+    # --- Automatic Diagram Generation ---
+    # Find all .puml files in docs/diagrams
+    file(GLOB PUML_FILES "${CMAKE_CURRENT_SOURCE_DIR}/docs/diagrams/*.puml")
+    
+    # Define the output directory for generated diagrams
+    set(DIAGRAM_GEN_DIR "${CMAKE_CURRENT_SOURCE_DIR}/docs/diagrams/output")
+
+    # Create a custom target to generate SVGs
+    # We use batch mode which automatically respects the filename defined in @startuml <name>
+    add_custom_target(generate_diagrams
+        COMMAND ${Java_JAVA_EXECUTABLE} -jar ${PLANTUML_PATH} -tsvg "${CMAKE_CURRENT_SOURCE_DIR}/docs/diagrams/*.puml" -o "${DIAGRAM_GEN_DIR}"
+        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+        COMMENT "Generating SVG diagrams with PlantUML..."
+        VERBATIM
+    )
+
 else()
-    message(STATUS "PlantUML not found. Diagrams in documentation might fail to generate.")
+    message(STATUS "PlantUML JAR not found. Diagrams in documentation might fail to generate.")
 endif()
 
 if (DOXYGEN_FOUND)
@@ -15,6 +44,11 @@ if (DOXYGEN_FOUND)
         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
         COMMENT "Generating API documentation with Doxygen"
         VERBATIM)
+    
+    # Make Doxygen depend on the diagrams being generated first
+    if (PLANTUML_PATH)
+        add_dependencies(doxygen generate_diagrams)
+    endif()
     
     # Target to run everything (Build + Docs)
     add_custom_target(full_build)

--- a/docs/Architecture.md
+++ b/docs/Architecture.md
@@ -1,0 +1,33 @@
+# Architecture & Design
+
+## 1. System Overview
+
+The **EnigmaMachineCore** is designed as a modular, configurable cryptographic engine. It separates the "business logic" of the Enigma cipher (Rotors, Reflectors, Plugboard) from the application layer (CLI).
+
+## 2. Use Cases
+
+The primary actors are the **Operator** (who sends messages) and the **Technician** (who configures the machine).
+
+![Use Case Diagram](diagrams/output/EnigmaCore_Use_Case_Diagram.svg)
+
+## 3. Component Architecture
+
+The system is built using an Object-Oriented approach with C++20.
+*   **EnigmaMachine:** The facade.
+*   **RotorBox:** Manages the complexity of the signal path through multiple rotors and the reflector.
+*   **PlugBoard:** Handles the initial and final character swaps.
+*   **Transformer:** The abstract base class for any component that transforms a signal (Rotor, Reflector).
+
+![Class Diagram](diagrams/output/EnigmaMachineCore_Class_Diagram.svg)
+
+## 4. Execution Flow
+
+The encryption process follows a strict physical signal path simulation:
+1.  **Plugboard Entry:** Input character is swapped.
+2.  **Rotor Stepping:** Mechanical movement occurs *before* the electrical signal passes.
+3.  **Forward Pass:** Signal goes through Rotors right-to-left.
+4.  **Reflection:** Signal hits the Reflector.
+5.  **Reverse Pass:** Signal returns through Rotors left-to-right.
+6.  **Plugboard Exit:** Output character is swapped again.
+
+![Encryption Sequence](diagrams/output/Enigma_Encryption_Sequence_Diagram.svg)

--- a/docs/diagrams/class_diagram.puml
+++ b/docs/diagrams/class_diagram.puml
@@ -1,0 +1,134 @@
+@startuml EnigmaMachineCore_Class_Diagram
+
+' Styling
+skinparam classAttributeIconSize 0
+skinparam monochrome true
+skinparam linetype ortho
+
+' Enums and Structs
+enum TransformerType {
+    NotDefined
+    Rotor
+    Reflector
+}
+
+class Pair_t <<struct>> {
+    + int a
+    + int b
+}
+
+class RotorConfig <<struct>> {
+    + notchPosition : int
+    + wiring : std::vector<int>
+}
+
+class ReflectorConfig <<struct>> {
+    + wiring : std::vector<int>
+}
+
+' Classes
+class EnigmaMachineConfig {
+    - rotorCount : int
+    - rotorPositions : std::vector<int>
+    - rotors : std::vector<RotorConfig>
+    - reflector : ReflectorConfig
+    - plugBoardPairs : std::array<Pair_t, PLUGBOARD_MAX_PAIRS>
+    + EnigmaMachineConfig()
+    + {static} load(fileName: std::string_view, assetPath: std::string_view) : EnigmaMachineConfig
+    + {static} loadRotor(fileName: std::string_view) : RotorConfig
+    + {static} loadReflector(fileName: std::string_view) : ReflectorConfig
+    + getRotorCount() : int
+    + getRotorPositions() : std::vector<int>
+    + getRotors() : std::vector<RotorConfig>
+    + getReflector() : ReflectorConfig
+    + getPlugBoardPairs() : std::array<Pair_t, PLUGBOARD_MAX_PAIRS>
+}
+
+class EnigmaMachine {
+    - rotorBox : RotorBox
+    - plugBoard : PlugBoard
+    + EnigmaMachine()
+    + EnigmaMachine(nRotorCount: int, rotorPositions: std::vector<int>, transformerFiles: std::vector<std::string>)
+    + EnigmaMachine(nRotorCount: int, rotorPositions: std::vector<int>, transformerFiles: std::vector<std::string>, plugBoardPairs: std::array<Pair_t, PLUGBOARD_MAX_PAIRS>)
+    + EnigmaMachine(config: EnigmaMachineConfig)
+    + EnigmaMachine(fileName: std::string_view, assetPath: std::string_view)
+    + ~EnigmaMachine()
+    + keyTransform(input: int) : int
+}
+
+class PlugBoard {
+    - mapping : std::array<int, TRANSFORMER_SIZE>
+    + PlugBoard()
+    + PlugBoard(pairs: std::array<Pair_t, PLUGBOARD_MAX_PAIRS>)
+    + ~PlugBoard()
+    + swap(key: int) : int
+}
+
+class RotorBox {
+    - nRotorCount : int
+    - rotorPositions : std::vector<int>
+    - transformerVec : std::vector<std::unique_ptr<Transformer>>
+    - initTransformerVec(nRotorCount: int, rotors: std::vector<RotorConfig>, reflector: ReflectorConfig) : void
+    - updateRotors() : void
+    + RotorBox()
+    + RotorBox(nRotorCount: int, rotorPositions: std::vector<int>, rotors: std::vector<RotorConfig>, reflector: ReflectorConfig)
+    + ~RotorBox()
+    + printTransformerVec() : void
+    + keyTransform(input: int) : int
+}
+
+abstract class Transformer {
+    - transformLUT : std::array<std::array<int, TRANSFORMER_SIZE>, 2>
+    # type : TransformerType
+    # setTransformValue(row: int, col: int, value: int) : void
+    # getTransformValue(row: int, col: int) : int
+    # fillTransformRow(row: int, value: int) : void
+    # getTransformRow(row: int) : const std::array<int, TRANSFORMER_SIZE>&
+    + Transformer()
+    + {abstract} ~Transformer()
+    + {abstract} transform(position: int, reverse: bool) : int
+    + {abstract} rotate() : int
+    + {abstract} setPosition(position: int) : void
+    + sizeOfTransformLUT() : int
+    + getType() : TransformerType
+}
+
+class Rotor {
+    - notchPosition : int
+    - rotorRotationCount : int
+    - initReverseTransformLUT() : void
+    - isNotchPosition(position: int) : bool
+    + Rotor(config: RotorConfig)
+    + ~Rotor()
+    + transform(position: int, reverse: bool) : int
+    + rotate() : int
+    + setPosition(position: int) : void
+}
+
+class Reflector {
+    + Reflector(config: ReflectorConfig)
+    + ~Reflector()
+    + transform(position: int, reverse: bool) : int
+    + rotate() : int
+}
+
+' Relationships
+EnigmaMachineConfig ..> RotorConfig
+EnigmaMachineConfig ..> ReflectorConfig
+EnigmaMachineConfig ..> Pair_t
+
+EnigmaMachine ..> EnigmaMachineConfig : uses
+EnigmaMachine *-- RotorBox
+EnigmaMachine *-- PlugBoard
+
+PlugBoard ..> Pair_t
+
+RotorBox o-- Transformer
+RotorBox ..> RotorConfig
+RotorBox ..> ReflectorConfig
+
+Transformer <|-- Rotor
+Transformer <|-- Reflector
+Transformer ..> TransformerType
+
+@enduml

--- a/docs/diagrams/encryption_sequence.puml
+++ b/docs/diagrams/encryption_sequence.puml
@@ -1,0 +1,72 @@
+@startuml Enigma_Encryption_Sequence_Diagram
+
+skinparam monochrome true
+skinparam responseMessageBelowArrow true
+
+actor User
+participant "EnigmaMachine" as EM
+participant "RotorBox" as RB
+participant "PlugBoard" as PB
+participant "Rotor (0)" as R0
+participant "Rotor (1)" as R1
+participant "Rotor (2)" as R2
+participant "Reflector" as REF
+
+User -> EM: keyTransform(inputChar)
+activate EM
+
+    note right of EM: 1. Electrical Signal Path (Plugboard Entry)
+    EM -> PB: swap(inputChar)
+    activate PB
+    PB --> EM: swappedChar
+    deactivate PB
+
+    note right of EM: 2. RotorBox Processing
+    EM -> RB: keyTransform(swappedChar)
+    activate RB
+
+        note right of RB: 2.1 Mechanical Step (Before Encrypting)
+        RB -> RB: updateRotors()
+        activate RB
+            RB -> R0: rotate()
+            alt notch hit
+                RB -> R1: rotate()
+                alt notch hit
+                    RB -> R2: rotate()
+                end
+            end
+        deactivate RB
+        
+        note right of RB: 2.2 Forward Pass (0 -> 1 -> 2)
+        RB -> R0: transform(char, reverse=false)
+        R0 --> RB: c1
+        RB -> R1: transform(c1, reverse=false)
+        R1 --> RB: c2
+        RB -> R2: transform(c2, reverse=false)
+        R2 --> RB: c3
+
+        note right of RB: 2.3 Reflection
+        RB -> REF: transform(c3)
+        REF --> RB: c4
+
+        note right of RB: 2.4 Reverse Pass (2 -> 1 -> 0)
+        RB -> R2: transform(c4, reverse=true)
+        R2 --> RB: c5
+        RB -> R1: transform(c5, reverse=true)
+        R1 --> RB: c6
+        RB -> R0: transform(c6, reverse=true)
+        R0 --> RB: c7
+
+    RB --> EM: outputChar
+    deactivate RB
+
+    note right of EM: 3. Electrical Signal Path (Plugboard Exit)
+    EM -> PB: swap(outputChar)
+    activate PB
+    PB --> EM: finalChar
+    deactivate PB
+
+EM --> User: finalChar
+deactivate EM
+
+@enduml

--- a/docs/diagrams/use_case.puml
+++ b/docs/diagrams/use_case.puml
@@ -1,0 +1,34 @@
+@startuml EnigmaCore_Use_Case_Diagram
+
+skinparam monochrome true
+left to right direction
+
+actor "Operator" as User
+actor "Technician" as Tech
+
+package "Enigma Machine System" {
+    
+    usecase "Encrypt/Decrypt Message" as UC1
+    usecase "Process Character" as UC3
+    
+    usecase "Configure Machine" as UC4
+    usecase "Load TOML Configuration" as UC5
+    usecase "Validate Wiring & Plugs" as UC5a
+    usecase "Set Rotor Positions" as UC6
+    
+    ' Relationships
+    User --> UC1
+    
+    UC1 ..> UC3 : <<include>>
+    
+    Tech --> UC4
+    UC4 ..> UC5 : <<include>>
+    UC5 ..> UC5a : <<include>>
+    UC4 <|-- UC6
+    
+    ' Note: In this system, encryption and decryption are symmetric operations
+    note "Symmetric Cipher:\nEncryption logic == Decryption logic" as N1
+    (UC1) .. N1
+}
+
+@enduml


### PR DESCRIPTION
## Description

- Updated Doxyfile.in to include 'docs/' and configure PlantUML path.
- Created 'docs/Architecture.md' with system overview and embedded diagrams.
- Added PlantUML diagrams: use_case.puml, class_diagram.puml, encryption_sequence.puml.
- Updated 'cmake/Doc.cmake' to automate SVG diagram generation into 'docs/diagrams/output'.
- Updated .gitignore to exclude generated diagram artifacts.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional changes, no api changes)
- [x] Tools update

## How Has This Been Validated?

By running
```bash
$ cd build && make doxygen
$ cd ..
$ firefox docs/doxygen-gen-files/html/index.html
```

**Test Configuration**:
* Compiler/Toolchain: CMake + PlantUML + Doxygen
* OS/Platform: Linux

## Checklist:

- [x] My code is documented with doxygen comments
- [x] I have made corresponding changes to the documentation
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Additional Information

No any additional information.

## Contributors

List of contributors to this pull request:
- @alvarocleite 
