### PR TITLE
fix diagram transparency and centering in docs

### DIFF
--- a/docs/Architecture.md
+++ b/docs/Architecture.md
@@ -7,12 +7,20 @@ The **EnigmaMachineCore** is a C++20 implementation of the Enigma cipher. It sep
 ### 1.1. Component Architecture
 The system is divided into a reusable Static Library (`EnigmaCore`) and a thin CLI Wrapper (`EnigmaMachineCore`).
 
+<div align="center">
+
 ![Component Diagram](diagrams/output/EnigmaMachineCore_Component_Diagram.svg)
+
+</div>
 
 ### 1.2. Deployment Architecture
 The system is designed for flexibility across different platforms. The deployment strategy varies between standard OS environments and embedded targets.
 
+<div align="center">
+
 ![Deployment View](diagrams/output/EnigmaMachineCore_Deployment_View.svg)
+
+</div>
 
 ## 2. Use Cases
 
@@ -20,13 +28,21 @@ The system serves two primary actors:
 *   **Operator:** Encrypts and decrypts messages.
 *   **Technician:** Configures the machine's state (Rotors, Plugs).
 
+<div align="center">
+
 ![Use Case Diagram](diagrams/output/EnigmaCore_Use_Case_Diagram.svg)
+
+</div>
 
 ## 3. Architectural Design
 
 The architecture is driven by **Separation of Concerns** and **Testability**, avoiding tight coupling between data, logic, and the filesystem.
 
+<div align="center">
+
 ![Class Diagram](diagrams/output/EnigmaMachineCore_Class_Diagram.svg)
+
+</div>
 
 ### 3.1. Data vs. Logic (SRP)
 The system strictly separates configuration data from the logic required to load it.
@@ -57,7 +73,11 @@ To allow external systems (User Interfaces, Loggers) to react to internal state 
 ### 3.5. Configuration Loading
 The initialization process orchestrates the `EnigmaConfigLoader`, `IAssetProvider`, and the underlying TOML parser to construct a valid machine state.
 
+<div align="center">
+
 ![Configuration Loading Sequence](diagrams/output/Enigma_Config_Loading_Sequence.svg)
+
+</div>
 
 ### 3.6. Error Handling Strategy
 The system uses **Exceptions** rather than error codes to handle runtime failures.
@@ -79,7 +99,15 @@ The encryption logic follows the physical signal path of the historical machine:
 ### 4.1. Rotor Stepping Logic
 The mechanical stepping is the most complex state transition in the system. A rotor rotates when the *previous* rotor passes its notch.
 
+<div align="center">
+
 ![State Machine](diagrams/output/Enigma_Rotor_State_Machine.svg)
 
+</div>
+
 ### 4.2. Signal Path Sequence
+<div align="center">
+
 ![Encryption Sequence](diagrams/output/Enigma_Encryption_Sequence_Diagram.svg)
+
+</div>

--- a/docs/diagrams/class_diagram.puml
+++ b/docs/diagrams/class_diagram.puml
@@ -3,6 +3,7 @@
 ' Styling
 skinparam classAttributeIconSize 0
 skinparam monochrome true
+skinparam backgroundColor white
 skinparam linetype ortho
 
 ' Enums and Structs

--- a/docs/diagrams/component_diagram.puml
+++ b/docs/diagrams/component_diagram.puml
@@ -1,6 +1,7 @@
 @startuml EnigmaMachineCore_Component_Diagram
 
 skinparam monochrome true
+skinparam backgroundColor white
 skinparam componentStyle uml2
 
 package "EnigmaMachineCore (Executable)" {

--- a/docs/diagrams/config_loading_sequence.puml
+++ b/docs/diagrams/config_loading_sequence.puml
@@ -1,6 +1,7 @@
 @startuml Enigma_Config_Loading_Sequence
 
 skinparam monochrome true
+skinparam backgroundColor white
 skinparam responseMessageBelowArrow true
 
 actor "Main App" as App

--- a/docs/diagrams/deployment_view.puml
+++ b/docs/diagrams/deployment_view.puml
@@ -1,6 +1,7 @@
 @startuml EnigmaMachineCore_Deployment_View
 
 skinparam monochrome true
+skinparam backgroundColor white
 skinparam componentStyle uml2
 
 node "Host System (Linux/Windows/macOS)" as Host {

--- a/docs/diagrams/encryption_sequence.puml
+++ b/docs/diagrams/encryption_sequence.puml
@@ -1,6 +1,7 @@
 @startuml Enigma_Encryption_Sequence_Diagram
 
 skinparam monochrome true
+skinparam backgroundColor white
 skinparam responseMessageBelowArrow true
 
 actor User

--- a/docs/diagrams/rotor_state_machine.puml
+++ b/docs/diagrams/rotor_state_machine.puml
@@ -1,6 +1,7 @@
 @startuml Enigma_Rotor_State_Machine
 
 skinparam monochrome true
+skinparam backgroundColor white
 skinparam state {
     BackgroundColor White
     BorderColor Black

--- a/docs/diagrams/use_case.puml
+++ b/docs/diagrams/use_case.puml
@@ -1,6 +1,7 @@
 @startuml EnigmaCore_Use_Case_Diagram
 
 skinparam monochrome true
+skinparam backgroundColor white
 left to right direction
 
 ' Actors


### PR DESCRIPTION
## Description

Standardize the visual appearance of all architectural diagrams by:
- Adding 'skinparam backgroundColor white' to PlantUML source files to prevent transparency issues in different viewing modes.
- Centering diagram output in 'Architecture.md' using HTML div alignment for a more professional and consistent layout.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Tools update

## How Has This Been Validated?

It will be validated in doxygen doc with get to main

**Test Configuration**:
* Compiler/Toolchain: Doxygen
* OS/Platform: Linux

## Checklist:

- [x] My code is documented with doxygen comments
- [x] I have made corresponding changes to the documentation
- [-] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [-] My changes generate no new warnings
- [-] I have added tests that prove my fix is effective or that my feature works
- [-] New and existing unit tests pass locally with my changes

## Additional Information

No additional information.

## Contributors

List of contributors to this pull request:
- @alvarocleite 
