### PR TITLE
wildcard pattern for PlantUML diagram generation

### DIFF
--- a/cmake/Doc.cmake
+++ b/cmake/Doc.cmake
@@ -28,7 +28,7 @@ if (PLANTUML_PATH)
     # We use batch mode which automatically respects the filename defined in @startuml <name>
     add_custom_target(generate_diagrams
         COMMAND ${CMAKE_COMMAND} -E make_directory "${DIAGRAM_GEN_DIR}"
-        COMMAND ${Java_JAVA_EXECUTABLE} -jar ${PLANTUML_PATH} -tsvg "${CMAKE_CURRENT_SOURCE_DIR}/docs/diagrams" -o "${DIAGRAM_GEN_DIR}"
+        COMMAND ${Java_JAVA_EXECUTABLE} -jar ${PLANTUML_PATH} -tsvg "${CMAKE_CURRENT_SOURCE_DIR}/docs/diagrams/*.puml" -o "${DIAGRAM_GEN_DIR}"
         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
         COMMENT "Generating SVG diagrams with PlantUML..."
         VERBATIM


### PR DESCRIPTION
## Description

Update the PlantUML command in 'cmake/Doc.cmake' to explicitly target source files using the '*.puml' wildcard pattern.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional changes, no api changes)
- [x] Tools update

## How Has This Been Validated?

An GH Action workflow was run: https://github.com/alvarocleite/EnigmaMachineCore/actions/runs/21312338976 

(run fails only becouse of deployment, it is not permited from a feature branch)

**Test Configuration**: 
* Compiler/Toolchain: GH action, CMake, PlantUML
* OS/Platform: Linux

## Checklist:

- [-] My code is documented with doxygen comments
- [-] I have made corresponding changes to the documentation
- [-] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [-] My changes generate no new warnings
- [-] I have added tests that prove my fix is effective or that my feature works
- [-] New and existing unit tests pass locally with my changes

## Additional Information

No additional information needed.

## Contributors

List of contributors to this pull request:
- @alvarocleite 
