### PR TITLE
Add support for Enigma Core be imported as library

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -44,7 +44,7 @@ jobs:
         # This target depends on 'generate_diagrams', so it will:
         # 1. Generate SVG diagrams from PlantUML files
         # 2. Run Doxygen to generate the HTML site
-        run: cmake --build build --target doxygen
+        run: cmake --build build --target Enigma_doxygen
 
       - name: Setup Pages
         uses: actions/configure-pages@v5

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -22,7 +22,7 @@ jobs:
         sudo apt-get install -y clang-tidy
 
     - name: Configure CMake
-      run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=Debug -DENABLE_CLANG_TIDY=ON
+      run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=Debug -DENIGMA_ENABLE_CLANG_TIDY=ON
 
     - name: Run Analysis
       # Building the target triggers clang-tidy as configured in CMakeLists.txt

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,3 @@
-
 # Minimum CMake version required
 cmake_minimum_required(VERSION 3.15)
 
@@ -9,6 +8,19 @@ endif()
 
 # Define project name, version, and language
 project(EnigmaMachineCore VERSION 0.0.1 LANGUAGES CXX)
+
+# --- Submodule Support & Options ---
+# Check if this project is the top-level project
+if(CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME)
+    set(ENIGMA_IS_TOP_LEVEL ON)
+else()
+    set(ENIGMA_IS_TOP_LEVEL OFF)
+endif()
+
+# Define options to control build targets
+option(ENIGMA_BUILD_CLI "Build the Enigma Machine CLI executable" ${ENIGMA_IS_TOP_LEVEL})
+option(ENIGMA_BUILD_TESTS "Build the test suite" ${ENIGMA_IS_TOP_LEVEL})
+option(ENIGMA_BUILD_DOCS "Build the documentation" ${ENIGMA_IS_TOP_LEVEL})
 
 # --- C++ Standard ---
 set(CMAKE_CXX_STANDARD 20)
@@ -29,20 +41,19 @@ set(CORE_SOURCES
     RotorBox/src/Rotor.cpp
 )
 
-# Application entry point
-set(APP_SOURCES
-    app/main.cpp
-)
-
 # Create Target (EnigmaCore)
 # Create a static library contains the business logic, to be testable without main()
 add_library(EnigmaCore STATIC
     ${CORE_SOURCES}
 )
 
+# Create namespaced alias for safer consumption
+add_library(EnigmaMachineCore::EnigmaCore ALIAS EnigmaCore)
+
 # --- Include Directories ---
 # Define search paths for header files
 set(INCLUDE_DIRS
+    ${CMAKE_CURRENT_SOURCE_DIR}/include
     ${CMAKE_CURRENT_SOURCE_DIR}/RotorBox/include
     ${CMAKE_CURRENT_SOURCE_DIR}/PlugBoard/include
     ${CMAKE_CURRENT_SOURCE_DIR}/EnigmaMachine/include
@@ -61,9 +72,9 @@ else()
 endif()
 
 # --- Static Analysis (clang-tidy) ---
-option(ENABLE_CLANG_TIDY "Enable static analysis with clang-tidy" OFF)
+option(ENIGMA_ENABLE_CLANG_TIDY "Enable static analysis with clang-tidy" OFF)
 
-if(ENABLE_CLANG_TIDY)
+if(ENIGMA_ENABLE_CLANG_TIDY)
     find_program(CLANG_TIDY_EXE clang-tidy)
     if(CLANG_TIDY_EXE)
         message(STATUS "clang-tidy found: ${CLANG_TIDY_EXE}")
@@ -86,43 +97,54 @@ endif()
 add_subdirectory(external/toml11)
 target_link_libraries(EnigmaCore PUBLIC toml11::toml11)
 
-# Initialize and link CLI11 library
-add_subdirectory(external/CLI11)
-
 # --- Main Executable Target ---
-# The EnigmaMachineCore application executable, which is just a wrapper around the EnigmaCore
-add_executable(${PROJECT_NAME}
-    ${APP_SOURCES}
-)
+if(ENIGMA_BUILD_CLI)
+    # Application entry point
+    set(APP_SOURCES
+        app/main.cpp
+    )
 
-# Link the core library logic to the executable
-target_link_libraries(${PROJECT_NAME} PRIVATE EnigmaCore CLI11::CLI11)
+    # Initialize and link CLI11 library (Only needed for the CLI app)
+    add_subdirectory(external/CLI11)
 
-# --- Asset Handling ---
-# Copy assets to build directory after build
-add_custom_command(TARGET ${PROJECT_NAME} POST_BUILD
-    COMMAND ${CMAKE_COMMAND} -E copy_directory
-        ${CMAKE_CURRENT_SOURCE_DIR}/assets
-        ${CMAKE_CURRENT_BINARY_DIR}/assets
-    COMMENT "Copying assets to build directory"
-)
+    # The EnigmaMachineCore application executable, which is just a wrapper around the EnigmaCore
+    add_executable(${PROJECT_NAME}
+        ${APP_SOURCES}
+    )
+
+    # Link the core library logic to the executable
+    target_link_libraries(${PROJECT_NAME} PRIVATE EnigmaMachineCore::EnigmaCore CLI11::CLI11)
+
+    # --- Asset Handling ---
+    # Copy assets to build directory after build
+    add_custom_command(TARGET ${PROJECT_NAME} POST_BUILD
+        COMMAND ${CMAKE_COMMAND} -E copy_directory
+            ${CMAKE_CURRENT_SOURCE_DIR}/assets
+            ${CMAKE_CURRENT_BINARY_DIR}/assets
+        COMMENT "Copying assets to build directory"
+    )
+endif()
 
 # --- Documentation ---
 # Include external module for Doxygen and PlantUML configuration
-include(cmake/Doc.cmake)
+if(ENIGMA_BUILD_DOCS)
+    include(cmake/Doc.cmake)
+endif()
 
 # --- Testing (GoogleTest) ---
-include(FetchContent)
-FetchContent_Declare(
-  googletest
-  URL https://github.com/google/googletest/archive/refs/tags/v1.14.0.zip
-)
-# For Windows: Prevent overriding the parent project's compiler/linker settings
-set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
-FetchContent_MakeAvailable(googletest)
+if(ENIGMA_BUILD_TESTS)
+    include(FetchContent)
+    FetchContent_Declare(
+    googletest
+    URL https://github.com/google/googletest/archive/refs/tags/v1.14.0.zip
+    )
+    # For Windows: Prevent overriding the parent project's compiler/linker settings
+    set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
+    FetchContent_MakeAvailable(googletest)
 
-enable_testing()
-add_subdirectory(tests)
+    enable_testing()
+    add_subdirectory(tests)
+endif()
 
 # --- Code Formatting (clang-format) ---
 find_program(CLANG_FORMAT_EXE clang-format)
@@ -135,11 +157,11 @@ if(CLANG_FORMAT_EXE)
     )
     list(APPEND ALL_SOURCES "app/main.cpp" "config/config.hpp")
     
-    add_custom_target(format
+    add_custom_target(enigma_format
         COMMAND ${CLANG_FORMAT_EXE} -i -style=file ${ALL_SOURCES}
         COMMENT "Formatting source code with clang-format"
-        WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
     )
 else()
-    message(WARNING "clang-format not found. The 'format' target will not be available.")
+    message(WARNING "clang-format not found. The 'enigma_format' target will not be available.")
 endif()

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ If you have Doxygen installed, you can generate the project documentation.
 
 **Using the modern CMake CLI:**
 ```bash
-cmake --build build --target doxygen
+cmake --build build --target Enigma_doxygen
 ```
 
 **Using the traditional Makefile approach:**
@@ -75,14 +75,14 @@ HTML documentation is generated in: `docs/doxygen-gen-files/html/index.html`
 This project uses `clang-format` to maintain a consistent coding style. To format all source files:
 
 ```bash
-cmake --build build --target format
+cmake --build build --target enigma_format
 ```
 
 ### Static Analysis
 The project integrates `clang-tidy` to detect bugs and enforce modern C++ practices. This check is optional and can be enabled during configuration:
 
 ```bash
-cmake -DENABLE_CLANG_TIDY=ON ..
+cmake -DENIGMA_ENABLE_CLANG_TIDY=ON ..
 ```
 
 ## Contributing

--- a/app/main.cpp
+++ b/app/main.cpp
@@ -3,7 +3,7 @@
 #include <cctype>
 #include <iostream>
 #include <string>
-#include "EnigmaMachine.hpp"
+#include "EnigmaCore.hpp"
 
 #include "config.hpp"
 

--- a/cmake/Doc.cmake
+++ b/cmake/Doc.cmake
@@ -26,7 +26,7 @@ if (PLANTUML_PATH)
 
     # Create a custom target to generate SVGs
     # We use batch mode which automatically respects the filename defined in @startuml <name>
-    add_custom_target(generate_diagrams
+    add_custom_target(Enigma_generate_diagrams
         COMMAND ${CMAKE_COMMAND} -E make_directory "${DIAGRAM_GEN_DIR}"
         COMMAND ${Java_JAVA_EXECUTABLE} -jar ${PLANTUML_PATH} -tsvg "${CMAKE_CURRENT_SOURCE_DIR}/docs/diagrams/*.puml" -o "${DIAGRAM_GEN_DIR}"
         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
@@ -40,7 +40,7 @@ endif()
 
 if (DOXYGEN_FOUND)
     configure_file(${CMAKE_CURRENT_SOURCE_DIR}/Doxyfile.in ${CMAKE_CURRENT_BINARY_DIR}/Doxyfile @ONLY)
-    add_custom_target(doxygen
+    add_custom_target(Enigma_doxygen
         COMMAND ${DOXYGEN_EXECUTABLE} ${CMAKE_CURRENT_BINARY_DIR}/Doxyfile
         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
         COMMENT "Generating API documentation with Doxygen"
@@ -48,12 +48,20 @@ if (DOXYGEN_FOUND)
     
     # Make Doxygen depend on the diagrams being generated first
     if (PLANTUML_PATH)
-        add_dependencies(doxygen generate_diagrams)
+        add_dependencies(Enigma_doxygen Enigma_generate_diagrams)
     endif()
     
     # Target to run everything (Build + Docs)
-    add_custom_target(full_build)
-    add_dependencies(full_build ${PROJECT_NAME} doxygen)
+    # Only add dependency on the executable if it is actually being built
+    add_custom_target(Enigma_full_build)
+    add_dependencies(Enigma_full_build Enigma_doxygen)
+    
+    if(ENIGMA_BUILD_CLI)
+         add_dependencies(Enigma_full_build ${PROJECT_NAME})
+    else()
+         add_dependencies(Enigma_full_build EnigmaCore)
+    endif()
+
 else()
     message(WARNING "Doxygen not found in the system. Documentation will not be generated.")
 endif()

--- a/docs/Building.md
+++ b/docs/Building.md
@@ -132,7 +132,7 @@ To ensure a consistent style, the project uses `clang-format` based on the Googl
 
 ### To format the source code:
 ```bash
-cmake --build build --target format
+cmake --build build --target enigma_format
 ```
 
 This will automatically format all source and header files in the project.
@@ -143,9 +143,9 @@ This will automatically format all source and header files in the project.
 
 Static analysis is performed using **clang-tidy** and is integrated into the CMake build system.
 
-*   **How to Enable:** By default, static analysis is disabled to ensure fast build times. To enable it, use the `ENABLE_CLANG_TIDY` flag during configuration:
+*   **How to Enable:** By default, static analysis is disabled to ensure fast build times. To enable it, use the `ENIGMA_ENABLE_CLANG_TIDY` flag during configuration:
     ```bash
-    cmake -DENABLE_CLANG_TIDY=ON -S . -B build
+    cmake -DENIGMA_ENABLE_CLANG_TIDY=ON -S . -B build
     ```
 *   **Execution:** Once enabled, clang-tidy will run on every source file during compilation (`make`).
 *   **Identifying Issues:** Clang-tidy output is interleaved with compiler output. You can distinguish them by the bracketed check name at the end of the line (e.g., `[modernize-use-auto]`). Standard compiler warnings typically start with `-W`.
@@ -160,7 +160,7 @@ If you have Doxygen and PlantUML installed, you can generate the project's API d
 ### To generate the documentation:
 
 ```bash
-cmake --build build --target doxygen
+cmake --build build --target Enigma_doxygen
 ```
 
 This command will:
@@ -173,8 +173,6 @@ The generated HTML documentation can be found at:
 `docs/doxygen-gen-files/html/index.html`
 
 Open this file in any web browser to view the interactive documentation.
-
----
 
 ## VS Code Integration
 
@@ -191,3 +189,25 @@ The project includes pre-configured settings for Visual Studio Code to streamlin
 *   **Test Explorer:** If you have the **CMake Tools** extension installed, you can use the Test Explorer (beaker icon) to run or debug individual tests.
 
 ---
+
+## Submodule Support
+
+This project is designed to be easily embedded as a submodule in other CMake projects.
+
+*   **Default Behavior:** When included via `add_subdirectory()`, the build system automatically detects it is not the top-level project and **disables** the CLI executable, tests, and documentation targets to keep your build clean.
+*   **Configuration Options:** You can override this behavior by setting these variables before adding the subdirectory:
+
+    ```cmake
+    set(ENIGMA_BUILD_CLI ON)   # Build the CLI executable
+    set(ENIGMA_BUILD_TESTS ON) # Build the test suite
+    set(ENIGMA_BUILD_DOCS ON)  # Build documentation targets
+    add_subdirectory(external/EnigmaMachineCore)
+    ```
+
+*   **Integration:** Link against the `EnigmaCore` library and include the public header:
+    ```cmake
+    target_link_libraries(MyTarget PRIVATE EnigmaMachineCore::EnigmaCore)
+    ```
+    ```cpp
+    #include <EnigmaCore.hpp>
+    ```

--- a/include/EnigmaCore.hpp
+++ b/include/EnigmaCore.hpp
@@ -1,0 +1,24 @@
+/**
+ * @file EnigmaCore.hpp
+ * @brief Public API gateway for the EnigmaCore library.
+ *
+ * This header serves as the single entry point for library consumers,
+ * including all necessary headers to interact with the Enigma Machine.
+ */
+
+#pragma once
+
+// Core Engine
+#include "EnigmaMachine.hpp"
+#include "EnigmaMachineConfig.hpp"
+#include "IEnigmaObserver.hpp"
+
+// Asset Management
+#include "IAssetProvider.hpp"
+#include "FileAssetProvider.hpp"
+
+// Components (Optional for direct interaction)
+#include "Rotor.hpp"
+#include "Reflector.hpp"
+#include "PlugBoard.hpp"
+#include "RotorBox.hpp"

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -12,7 +12,7 @@ add_executable(EnigmaTests
 
 # Link against the Core library and GTest
 # GTest::gtest_main includes the main() entry point for the test runner
-target_link_libraries(EnigmaTests PRIVATE EnigmaCore GTest::gtest_main)
+target_link_libraries(EnigmaTests PRIVATE EnigmaMachineCore::EnigmaCore GTest::gtest_main)
 
 # Register tests so CTest can find them
 include(GoogleTest)


### PR DESCRIPTION
## Description

- implement public API gateway header
- implement public API gateway submodule support
- implement target namespacing for the core library

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional changes, no api changes)
- [x] Tools update

## How Has This Been Validated?

Tests were run

**Test Configuration**:
* Compiler/Toolchain: CMake, Gtest, GCC
* OS/Platform: Linux

## Checklist:

- [x] My code is documented with doxygen comments
- [x] I have made corresponding changes to the documentation
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Additional Information

No additional information needed.

## Contributors

List of contributors to this pull request:
- @alvarocleite 
