### PR TITLE
Implement proxy observer pattern in EnigmaMachine

### DIFF
--- a/EnigmaMachine/include/EnigmaMachine.hpp
+++ b/EnigmaMachine/include/EnigmaMachine.hpp
@@ -21,7 +21,7 @@
  * This class encapsulates the functionality of the Enigma machine, including the rotor box
  * and the transformation of input keys through the rotors and reflector.
  */
-class EnigmaMachine {
+class EnigmaMachine : public IEnigmaObserver {
 private:
     RotorBox rotorBox;
     PlugBoard plugBoard;  // Optional: if you want to include a plugboard for additional transformations
@@ -103,7 +103,13 @@ public:
      * @throws std::runtime_error If the file cannot be parsed or contains invalid configuration data.
      */
     EnigmaMachine(std::string_view fileName, std::string_view assetPath = "");
-    ~EnigmaMachine() = default;
+
+    // Rule of Five
+    ~EnigmaMachine() override;
+    EnigmaMachine(const EnigmaMachine&) = delete;
+    EnigmaMachine& operator=(const EnigmaMachine&) = delete;
+    EnigmaMachine(EnigmaMachine&& other) noexcept;
+    EnigmaMachine& operator=(EnigmaMachine&& other) noexcept;
 
     /**
      * @brief Transforms the input key through the rotor box.
@@ -124,4 +130,8 @@ public:
      * @param observer The observer to remove.
      */
     void removeObserver(IEnigmaObserver* observer);
+
+    // IEnigmaObserver implementation
+    void onRotorStepped(int rotorIndex, int position) override;
+    void onCharEncrypted(char input, char output) override;
 };

--- a/EnigmaMachine/src/EnigmaMachine.cpp
+++ b/EnigmaMachine/src/EnigmaMachine.cpp
@@ -32,6 +32,7 @@ EnigmaMachine::EnigmaMachine() {
             EnigmaConfigLoader::loadReflector(provider, std::string(assetsDir) + std::string(defaultReflectorFile));
 
         rotorBox = RotorBox(3, {0, 0, 0}, rotors, reflector);
+        rotorBox.registerObserver(this);
     } catch (const std::exception& e) {
         std::cerr << "Failed to initialize default EnigmaMachine: " << e.what() << "\n";
         throw;
@@ -57,6 +58,7 @@ EnigmaMachine::EnigmaMachine(int nRotorCount, const std::vector<int>& rotorPosit
     ReflectorConfig reflector = EnigmaConfigLoader::loadReflector(provider, transformerFiles[nRotorCount]);
 
     rotorBox = RotorBox(nRotorCount, rotorPositions, rotors, reflector);
+    rotorBox.registerObserver(this);
 }
 
 /**
@@ -79,6 +81,7 @@ EnigmaMachine::EnigmaMachine(int nRotorCount, const std::vector<int>& rotorPosit
     ReflectorConfig reflector = EnigmaConfigLoader::loadReflector(provider, transformerFiles[nRotorCount]);
 
     rotorBox = RotorBox(nRotorCount, rotorPositions, rotors, reflector);
+    rotorBox.registerObserver(this);
 }
 
 EnigmaMachine::EnigmaMachine(IAssetProvider& provider, std::string_view fileName, std::string_view assetPath)
@@ -86,13 +89,40 @@ EnigmaMachine::EnigmaMachine(IAssetProvider& provider, std::string_view fileName
 
 EnigmaMachine::EnigmaMachine(const EnigmaMachineConfig& config)
     : rotorBox(config.rotorCount, config.rotorPositions, config.rotors, config.reflector),
-      plugBoard(config.plugBoardPairs) {}
+      plugBoard(config.plugBoardPairs) {
+    rotorBox.registerObserver(this);
+}
 
 EnigmaMachine::EnigmaMachine(std::string_view fileName, std::string_view assetPath)
     : EnigmaMachine([&]() {
           FileAssetProvider p;
           return EnigmaConfigLoader::load(p, fileName, assetPath);
       }()) {}
+
+EnigmaMachine::~EnigmaMachine() = default;
+
+EnigmaMachine::EnigmaMachine(EnigmaMachine&& other) noexcept
+    : rotorBox(std::move(other.rotorBox)),
+      plugBoard(std::move(other.plugBoard)),
+      observers(std::move(other.observers)) {
+    // The moved-from rotorBox (now in *this) still has 'other' as observer.
+    // We must update it to point to 'this'.
+    rotorBox.removeObserver(&other);
+    rotorBox.registerObserver(this);
+}
+
+EnigmaMachine& EnigmaMachine::operator=(EnigmaMachine&& other) noexcept {
+    if (this != &other) {
+        rotorBox = std::move(other.rotorBox);
+        plugBoard = std::move(other.plugBoard);
+        observers = std::move(other.observers);
+
+        // Fix observer pointer
+        rotorBox.removeObserver(&other);
+        rotorBox.registerObserver(this);
+    }
+    return *this;
+}
 
 /**
  * @details The transformation follows the historic Enigma signal path:
@@ -109,20 +139,28 @@ int EnigmaMachine::keyTransform(int input) {
     input = rotorBox.keyTransform(input);
     int output = plugBoard.swap(input);
 
-    for (auto* obs : observers) {
-        obs->onCharEncrypted(static_cast<char>('A' + originalInput), static_cast<char>('A' + output));
-    }
+    this->onCharEncrypted(static_cast<char>('A' + originalInput), static_cast<char>('A' + output));
 
     return output;
 }
 
-void EnigmaMachine::registerObserver(IEnigmaObserver* observer) {
-    observers.push_back(observer);
-    rotorBox.registerObserver(observer);
-}
+void EnigmaMachine::registerObserver(IEnigmaObserver* observer) { observers.push_back(observer); }
 
 void EnigmaMachine::removeObserver(IEnigmaObserver* observer) {
     auto it = std::remove(observers.begin(), observers.end(), observer);
-    observers.erase(it, observers.end());
-    rotorBox.removeObserver(observer);
+    if (it != observers.end()) {
+        observers.erase(it, observers.end());
+    }
+}
+
+void EnigmaMachine::onRotorStepped(int rotorIndex, int position) {
+    for (auto* obs : observers) {
+        obs->onRotorStepped(rotorIndex, position);
+    }
+}
+
+void EnigmaMachine::onCharEncrypted(char input, char output) {
+    for (auto* obs : observers) {
+        obs->onCharEncrypted(input, output);
+    }
 }

--- a/app/main.cpp
+++ b/app/main.cpp
@@ -17,10 +17,24 @@ struct AppConfig {
 };
 
 /**
+ * @brief Observer that logs Enigma machine events to the console.
+ */
+class ConsoleObserver : public IEnigmaObserver {
+public:
+    void onRotorStepped(int rotorIndex, int position) override {
+        std::cout << "[Event] Rotor " << rotorIndex << " stepped to position " << position << "\n";
+    }
+
+    void onCharEncrypted(char input, char output) override {
+        std::cout << "[Event] Encrypted: " << input << " -> " << output << "\n";
+    }
+};
+
+/**
  * @brief Processes a message through the Enigma Machine.
  * Transforms each character and optionally prints debug info.
  */
-std::string processMessage(EnigmaMachine& machine, const std::string& input, bool debug) {
+std::string processMessage(EnigmaMachine& machine, const std::string& input, bool /*debug*/) {
     std::string output = "";
     for (char c : input) {
         if (!std::isalpha(c)) {
@@ -29,10 +43,6 @@ std::string processMessage(EnigmaMachine& machine, const std::string& input, boo
         char upperC = std::toupper(c);
         char res = machine.keyTransform(upperC - 'A') + 'A';
         output += res;
-
-        if (debug) {
-            std::cout << "Input: " << upperC << ", Output: " << res << "\n";
-        }
     }
     return output;
 }
@@ -48,7 +58,7 @@ AppConfig parseArguments(int argc, char** argv) {
     app.add_option("-c,--config", config.configPath, "Path to the TOML configuration file");
     app.add_option("-a,--assets", config.assetPath, "Base directory for assets (rotors/reflectors)");
     app.add_option("-m,--message", config.message, "Message to process");
-    app.add_flag("-d,--debug", config.debug, "Enable character-by-character transformation output");
+    app.add_flag("-d,--debug", config.debug, "Enable verbose event logging (rotor steps, encryption details)");
     app.add_flag("--encode", config.encode, "Encode the message");
     app.add_flag("--decode", config.decode, "Decode the message");
 
@@ -69,6 +79,14 @@ AppConfig parseArguments(int argc, char** argv) {
 
 void runApplication(const AppConfig& config) {
     EnigmaMachine machine(config.configPath, config.assetPath);
+
+    // Create and register observer if debug is enabled
+    ConsoleObserver observer;
+    if (config.debug) {
+        machine.registerObserver(&observer);
+        std::cout << "Debug mode enabled: Observer registered.\n";
+    }
+
     std::string currentMessage = config.message;
 
     if (config.encode) {
@@ -80,6 +98,11 @@ void runApplication(const AppConfig& config) {
     if (config.decode) {
         // Re-initialize for decryption (symmetric cipher starting from same state)
         EnigmaMachine decodeMachine(config.configPath, config.assetPath);
+
+        // Register observer for the decode machine as well
+        if (config.debug) {
+            decodeMachine.registerObserver(&observer);
+        }
 
         std::cout << "Decoding message: " << currentMessage << "\n";
         std::string decoded = processMessage(decodeMachine, currentMessage, config.debug);

--- a/docs/Architecture.md
+++ b/docs/Architecture.md
@@ -58,7 +58,8 @@ The core engine does not access the filesystem directly.
 To allow external systems (User Interfaces, Loggers) to react to internal state changes without coupling the core engine to them, the system implements the **Observer Pattern**.
 
 *   **IEnigmaObserver:** An abstract interface defining callbacks for key events (`onRotorStepped`, `onCharEncrypted`).
-*   **Decoupling:** The `EnigmaMachine` maintains a list of observers but knows nothing about their concrete implementation. This allows the CLI to print logs or a GUI to animate spinning rotors simply by implementing this interface.
+*   **Proxy Pattern:** To minimize redundant logic, `EnigmaMachine` implements `IEnigmaObserver` and acts as a proxy. It registers itself as the sole observer of `RotorBox`. When `RotorBox` triggers a rotor step event, `EnigmaMachine` receives it and forwards it to all externally registered observers.
+*   **Decoupling:** The `EnigmaMachine` maintains a list of external observers but knows nothing about their concrete implementation. This allows the CLI to print logs or a GUI to animate spinning rotors simply by implementing this interface.
 
 ### 3.5. Configuration Loading
 

--- a/docs/diagrams/class_diagram.puml
+++ b/docs/diagrams/class_diagram.puml
@@ -70,6 +70,8 @@ class EnigmaMachine {
     + keyTransform(input: int) : int
     + registerObserver(observer: IEnigmaObserver*) : void
     + removeObserver(observer: IEnigmaObserver*) : void
+    + onRotorStepped(rotorIndex: int, position: int) : void
+    + onCharEncrypted(input: char, output: char) : void
 }
 
 class PlugBoard {
@@ -135,6 +137,7 @@ class Reflector {
 
 ' Relationships
 IAssetProvider <|.. FileAssetProvider : implements
+IEnigmaObserver <|.. EnigmaMachine : implements
 
 EnigmaConfigLoader ..> IAssetProvider : uses
 EnigmaConfigLoader ..> EnigmaMachineConfig : creates

--- a/docs/diagrams/encryption_sequence.puml
+++ b/docs/diagrams/encryption_sequence.puml
@@ -38,7 +38,10 @@ activate EM
             end
             
             loop for each observer
-                RB -> OBS: onRotorStepped(rotorIndex, pos)
+                RB -> EM: onRotorStepped(rotorIndex, pos)
+                activate EM
+                    EM -> OBS: onRotorStepped(rotorIndex, pos)
+                deactivate EM
             end
         deactivate RB
         


### PR DESCRIPTION
## Description

- Refactor EnigmaMachine to implement IEnigmaObserver and act as a proxy for RotorBox events.
- Implement custom move semantics (Rule of Five) in EnigmaMachine to maintain valid observer registration after moves.
- Update CLI application to utilize a dedicated ConsoleObserver for structured debug logging.
- Update architectural documentation and PlantUML diagrams to reflect the refined event flow.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Refactoring (no functional changes, no api changes)
- [ ] Tools update

## How Has This Been Validated?

Run gTests

**Test Configuration**:
* Compiler/Toolchain: Cmake, gcc, gTest
* OS/Platform: Linux

## Checklist:

- [x] My code is documented with doxygen comments
- [x] I have made corresponding changes to the documentation
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Additional Information

No additional information needed.

## Contributors

List of contributors to this pull request:
- @alvarocleite 
