### PR TITLE
adding const qualifier to const class methods

### DIFF
--- a/RotorBox/include/Rotor.hpp
+++ b/RotorBox/include/Rotor.hpp
@@ -40,7 +40,7 @@ private:
      * @param position The position to check.
      * @return true if the position is the notch position, false otherwise.
      */
-    inline bool isNotchPosition(int position);
+    inline bool isNotchPosition(int position) const;
 
 public:
     /**

--- a/RotorBox/include/RotorBox.hpp
+++ b/RotorBox/include/RotorBox.hpp
@@ -87,7 +87,7 @@ public:
      * @brief Prints the types of transformers in the transformer vector.
      * This function iterates through the transformer vector and prints the type of each transformer.
      */
-    void printTransformerVec();
+    void printTransformerVec() const;
 
     /**
      * @brief Transforms the input key through the rotor box.

--- a/RotorBox/src/Rotor.cpp
+++ b/RotorBox/src/Rotor.cpp
@@ -69,7 +69,7 @@ int Rotor::initRotorPosition(int offset) {
     return 0;
 }
 
-inline bool Rotor::isNotchPosition(int position) { return (position == notchPosition); }
+inline bool Rotor::isNotchPosition(int position) const { return (position == notchPosition); }
 
 /**
  * @details Handles the relative coordinate shift caused by the rotor's rotation.

--- a/RotorBox/src/RotorBox.cpp
+++ b/RotorBox/src/RotorBox.cpp
@@ -73,7 +73,7 @@ void RotorBox::initTransformerVec(int nRotorCount, const std::vector<RotorConfig
     transformerVec.push_back(std::make_unique<Reflector>(reflector));
 }
 
-void RotorBox::printTransformerVec() {
+void RotorBox::printTransformerVec() const {
     for (auto& transformer : transformerVec) {
         std::cout << "Transformer Type: " << static_cast<int>(transformer->getType()) << "\n";
     }


### PR DESCRIPTION
## Description

Addressing Issue #18 by adding const qualifier to class methods that should be const.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Refactoring (no functional changes, no api changes)
- [ ] Tools update

## How Has This Been Validated?

clang-tidy static analyzer was used to identify potential const-qualified class methods. All existing test pass as well.

**Test Configuration**:
* Compiler/Toolchain: g++ & clang++
* OS/Platform: Linux WSL

## Checklist:

- [ ] My code is documented with doxygen comments
- [ ] I have made corresponding changes to the documentation
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Additional Information

class_diagram.puml does not seem to document class method qualifiers. So no changes were made there.

## Contributors

List of contributors to this pull request:
@caliph1998
