### PR TITLE
Resolve Windows build errors and naming conflicts

### DIFF
--- a/EnigmaMachine/src/EnigmaConfigLoader.cpp
+++ b/EnigmaMachine/src/EnigmaConfigLoader.cpp
@@ -37,7 +37,7 @@ void validateTransformerConfig(const toml::value& data, const std::string& expec
 }  // namespace
 
 RotorConfig EnigmaConfigLoader::loadRotor(IAssetProvider& provider, const FileName& fileName) {
-    std::istringstream stream(provider.loadAsset(fileName.native()));
+    std::istringstream stream(provider.loadAsset(fileName.string()));
     // Parse from stream, pass filename for error reporting
     auto rotorData = toml::parse(stream, fileName.string());
     validateTransformerConfig(rotorData, "rotor", fileName.string());
@@ -53,14 +53,14 @@ RotorConfig EnigmaConfigLoader::loadRotor(IAssetProvider& provider, const FileNa
 }
 
 ReflectorConfig EnigmaConfigLoader::loadReflector(IAssetProvider& provider, const FileName& fileName) {
-    std::istringstream stream(provider.loadAsset(fileName.native()));
+    std::istringstream stream(provider.loadAsset(fileName.string()));
     auto reflectorData = toml::parse(stream, fileName.string());
     validateTransformerConfig(reflectorData, "reflector", fileName.string());
 
     ReflectorConfig reflectorConfig;
     reflectorConfig.wiring = toml::find<std::vector<int>>(reflectorData, "reflector", "map");
     if (reflectorConfig.wiring.size() != TRANSFORMER_SIZE) {
-        throw std::runtime_error("Error: Reflector wiring size mismatch in " + std::string(fileName));
+        throw std::runtime_error("Error: Reflector wiring size mismatch in " + fileName.string());
     }
     return reflectorConfig;
 }
@@ -68,7 +68,7 @@ ReflectorConfig EnigmaConfigLoader::loadReflector(IAssetProvider& provider, cons
 EnigmaMachineConfig EnigmaConfigLoader::load(IAssetProvider& provider, const FileName& fileName,
                                              const AssetPath& assetPath) {
     EnigmaMachineConfig config;
-    std::istringstream stream(provider.loadAsset(fileName.native()));
+    std::istringstream stream(provider.loadAsset(fileName.string()));
     auto data = toml::parse(stream, fileName.string());
 
     int rotorCount = toml::find<int>(data, "rotors", "RotorCount");

--- a/RotorBox/include/RotorBox.hpp
+++ b/RotorBox/include/RotorBox.hpp
@@ -27,11 +27,11 @@ private:
     /**
      * @brief Initializes the transformer vector with rotors and a reflector.
      *
-     * @param nRotorCount The number of rotors to be initialized.
+     * @param count The number of rotors to be initialized.
      * @param rotors A vector containing the configuration for each rotor.
      * @param reflector Configuration for the reflector.
      */
-    void initTransformerVec(int nRotorCount, const std::vector<RotorConfig>& rotors, const ReflectorConfig& reflector);
+    void initTransformerVec(int count, const std::vector<RotorConfig>& rotors, const ReflectorConfig& reflector);
 
     /**
      * @brief Updates the positions of the rotors.
@@ -51,14 +51,14 @@ public:
      * @brief Constructor for the RotorBox class.
      * Initializes the rotor box with a specified number of rotors, their positions, and configurations.
      *
-     * @param nRotorCount The number of rotors in the rotor box.
+     * @param count The number of rotors in the rotor box.
      * @param rotorPositions A vector containing the initial positions of each rotor.
      * @param rotors A vector containing the configuration for each rotor.
      * @param reflector Configuration for the reflector.
      * @throws std::invalid_argument If the number of rotors does not match the number of positions.
      * @throws std::runtime_error If initialization of transformers fails.
      */
-    RotorBox(int nRotorCount, const std::vector<int>& rotorPositions, const std::vector<RotorConfig>& rotors,
+    RotorBox(int count, const std::vector<int>& rotorPositions, const std::vector<RotorConfig>& rotors,
              const ReflectorConfig& reflector);
 
     // Disable Copy

--- a/RotorBox/src/RotorBox.cpp
+++ b/RotorBox/src/RotorBox.cpp
@@ -57,8 +57,7 @@ void RotorBox::removeObserver(IEnigmaObserver* observer) {
  * must contain exactly nRotorCount rotors followed by one reflector at the end.
  * Memory is managed via std::unique_ptr to ensure proper cleanup.
  */
-void RotorBox::initTransformerVec(int count, const std::vector<RotorConfig>& rotors,
-                                  const ReflectorConfig& reflector) {
+void RotorBox::initTransformerVec(int count, const std::vector<RotorConfig>& rotors, const ReflectorConfig& reflector) {
     transformerVec.clear();
     transformerVec.reserve(count + 1);
 

--- a/RotorBox/src/RotorBox.cpp
+++ b/RotorBox/src/RotorBox.cpp
@@ -24,21 +24,21 @@ RotorBox::RotorBox() { nRotorCount = 0; }
  * Validates that the number of provided positions matches the rotor count before
  * proceeding with transformer initialization and position setting.
  */
-RotorBox::RotorBox(int nRotorCount, const std::vector<int>& rotorPositions, const std::vector<RotorConfig>& rotors,
+RotorBox::RotorBox(int count, const std::vector<int>& rotorPositions, const std::vector<RotorConfig>& rotors,
                    const ReflectorConfig& reflector) {
-    if (std::cmp_not_equal(nRotorCount, rotorPositions.size())) {
+    if (std::cmp_not_equal(count, rotorPositions.size())) {
         throw std::invalid_argument("Error: Number of rotors and number of rotor positions do not match.");
     }
 
-    this->nRotorCount = nRotorCount;
+    this->nRotorCount = count;
     for (const auto& position : rotorPositions) {
         this->rotorPositions.push_back(position);
     }
 
     // Will throw if initialization fails
-    initTransformerVec(nRotorCount, rotors, reflector);
+    initTransformerVec(count, rotors, reflector);
 
-    for (int i = 0; i < nRotorCount; i++) {
+    for (int i = 0; i < count; i++) {
         transformerVec.at(i)->setPosition(this->rotorPositions.at(i));
     }
 }
@@ -57,13 +57,13 @@ void RotorBox::removeObserver(IEnigmaObserver* observer) {
  * must contain exactly nRotorCount rotors followed by one reflector at the end.
  * Memory is managed via std::unique_ptr to ensure proper cleanup.
  */
-void RotorBox::initTransformerVec(int nRotorCount, const std::vector<RotorConfig>& rotors,
+void RotorBox::initTransformerVec(int count, const std::vector<RotorConfig>& rotors,
                                   const ReflectorConfig& reflector) {
     transformerVec.clear();
-    transformerVec.reserve(nRotorCount + 1);
+    transformerVec.reserve(count + 1);
 
     // Validate input size: n Rotors
-    if (rotors.size() != (size_t)nRotorCount) {
+    if (rotors.size() != (size_t)count) {
         throw std::runtime_error("Error: Mismatch between rotor count and provided configurations.");
     }
 


### PR DESCRIPTION
## Description

what:
- Replaced 'path::native()' with 'path::string()' in EnigmaConfigLoader.cpp for asset loading.
- Replaced 'std::string(path)' with 'path.string()' in exception handling.
- Renamed 'nRotorCount' parameters to 'count' in RotorBox constructor and 'initTransformerVec'.

why:
- Windows returns a wide string (std::wstring) for 'native()', which is incompatible with the expected 'std::string_view' in 'loadAsset'
- The naming conflict in RotorBox triggered 'hides class member' warnings, which can lead to bugs and CI failures under strict build settings.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Tools update

## How Has This Been Validated?

Running compiler and gtests

**Test Configuration**:
* Compiler/Toolchain: g++ and CMake
* OS/Platform: Linux

## Checklist:

- [x] My code is documented with doxygen comments
- [ ] I have made corresponding changes to the documentation
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Additional Information

No additional information needed.

## Contributors

List of contributors to this pull request:
- @alvarocleite 
