### PR TITLE
Initialize architectural decision records (adrs)

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,8 @@ HTML documentation is generated in: `docs/doxygen-gen-files/html/index.html`
 
 For a detailed view of our future plans, architectural evolution, and platform support strategy (including WASM, Android, and Embedded targets), please refer to our [Project Roadmap](roadmap.md).
 
+Significant design choices and their rationales are documented in our [Architectural Decision Records (ADRs)](docs/adr/ADRs.md).
+
 ## Development
 
 ### Code Formatting

--- a/docs/Architecture.md
+++ b/docs/Architecture.md
@@ -1,5 +1,9 @@
 # Architecture & Design
 
+This document outlines the architectural design and key decisions behind the **EnigmaMachineCore** project. It provides an overview of the system's structure, components, and interactions, as well as the rationale behind major design choices.
+
+Significant architectural decisions, including their context, rationale, and consequences, are tracked in our [ADRs (Architectural Decision Records)](adr/ADRs.md).
+
 ## 1. System Overview
 
 The **EnigmaMachineCore** is a C++20 implementation of the Enigma cipher. It separates the cryptographic "Business Logic" from the application layer and the physical storage layer.

--- a/docs/adr/001-dependency-injection-for-assets.md
+++ b/docs/adr/001-dependency-injection-for-assets.md
@@ -1,0 +1,21 @@
+# ADR 001: Dependency Injection for Assets (IAssetProvider)
+
+## Status
+Accepted
+
+## Context
+The Enigma Machine Core is designed to be universal, supporting platforms from high-end Linux systems to low-end bare-metal microcontrollers and WebAssembly (WASM). Loading configuration files (TOML) directly from the filesystem (`std::ifstream`) creates a hard dependency on an OS-level filesystem, which is absent in many of our target environments (e.g., WASM, Zephyr RTOS).
+
+## Decision
+We will decouple the Enigma Engine from the physical filesystem by introducing the `IAssetProvider` interface.
+
+1.  **Interface:** `IAssetProvider` defines a single `loadAsset(assetName)` method that returns a `std::string` containing the asset's content.
+2.  **Decoupling:** The `EnigmaMachine` and its components will not perform file I/O. Instead, they will receive an `IAssetProvider` (Dependency Injection) and use it to retrieve configuration data.
+3.  **Implementations:**
+    *   `FileAssetProvider`: For platforms with a filesystem (CLI, Desktop).
+    *   `MemoryAssetProvider` (Planned): For platforms like WASM or Embedded where assets are pre-loaded or linked into the binary.
+
+## Consequences
+*   **Portability:** The engine can now run on platforms without a filesystem by providing a custom provider.
+*   **Testability:** Unit tests can use a mock provider to simulate configuration data without relying on disk files.
+*   **Complexity:** Slightly increases initialization complexity as a provider must be instantiated and passed to the machine.

--- a/docs/adr/002-signal-path-strategy.md
+++ b/docs/adr/002-signal-path-strategy.md
@@ -1,0 +1,21 @@
+# ADR 002: Signal Path Strategy (Alphabet Index vs. Raw Chars)
+
+## Status
+Accepted
+
+## Context
+The internal signal path of the Enigma Machine involves passing a character through multiple rotors and a reflector. There are two primary ways to represent this signal:
+1.  **Raw Characters:** Passing `char` values (e.g., 'A', 'B') and performing character arithmetic.
+2.  **Alphabet Indices:** Passing `int` values representing the index in the alphabet (e.g., 0-25 for a 26-letter alphabet).
+
+## Decision
+We will use **Alphabet Indices** (`int` values, 0-25) for all internal signal transformations within the `Transformer`, `RotorBox`, and `PlugBoard` classes.
+
+1.  **Semantic Consistency:** Transformations are mathematical mappings within a set. Using indices makes this mapping explicit.
+2.  **Performance:** Avoids repeated conversions between ASCII/UTF-8 and numeric indices during the hot path of encryption.
+3.  **Flexibility:** Easily supports non-standard alphabet sizes (e.g., 29 characters) by simply changing the `TRANSFORMER_SIZE` constant and updating the index range.
+4.  **Boundary Responsibility:** The `EnigmaMachine::keyTransform` (or a higher-level UI wrapper) is responsible for converting input `char` to `int` and back to `char` for the final output.
+
+## Consequences
+*   **Validation:** All internal components must enforce that inputs are within the valid [0, TRANSFORMER_SIZE-1] range.
+*   **Type Safety:** While `int` is used currently, future refactoring should consider strong typing (e.g., an `AlphabetIndex` class) to prevent accidental mixing of indices and raw values.

--- a/docs/adr/003-error-handling-strategy.md
+++ b/docs/adr/003-error-handling-strategy.md
@@ -1,0 +1,25 @@
+# ADR 003: Error Handling Strategy (Transition to std::expected)
+
+## Status
+Accepted
+
+## Context
+The Enigma Machine Core is designed to be universal, and it targets platforms that do not support exceptions (`-fno-exceptions`) or where exceptions are discouraged for performance reasons (e.g., Embedded systems, WASM).
+
+Currently, the engine uses:
+1.  **Exceptions:** `std::runtime_error` and `std::invalid_argument` are thrown in constructors and configuration loaders.
+2.  **Boolean Returns/Logging:** Some internal logic reports errors via `std::cerr` or simple boolean returns.
+
+## Decision
+We will transition from C++ exceptions to the **`std::expected`** (C++23) pattern for reporting errors in public and internal APIs.
+
+1.  **Value-Error Return:** Public-facing methods like `keyTransform` and configuration loaders will return a `Result<T>` (aliased to `std::expected<T, ErrorCode>`).
+2.  **No-Exceptions Compatibility:** This approach allows us to compile the engine with `-fno-exceptions` without losing error-reporting capability.
+3.  **Exception-Free Core:** After the transition, all `throw` statements in the core logic will be removed or conditionally enabled for rich targets only.
+4.  **Error Codes:** We will define a comprehensive set of `ErrorCode` values representing configuration failures, validation errors, and runtime issues.
+
+## Consequences
+*   **Portability:** The engine becomes fully compatible with constrained targets (embedded, WASM).
+*   **API Changes:** Most public methods will have their return signatures updated.
+*   **Verbosity:** Error checking becomes explicit in the caller, similar to Rust's `Result` or Go's error handling.
+*   **Dependency:** Since we use C++20, we may need a backport (like `tl::expected`) if C++23 is not yet available in all target compilers.

--- a/docs/adr/ADRs.md
+++ b/docs/adr/ADRs.md
@@ -1,0 +1,9 @@
+# Architectural Decision Records (ADRs)
+
+This directory contains records of significant architectural decisions made for the EnigmaMachineCore project.
+
+## Index
+
+* [ADR 001: Dependency Injection for Assets (IAssetProvider)](001-dependency-injection-for-assets.md)
+* [ADR 002: Signal Path Strategy (Alphabet Index vs. Raw Chars)](002-signal-path-strategy.md)
+* [ADR 003: Error Handling Strategy (Transition to std::expected)](003-error-handling-strategy.md)

--- a/roadmap.md
+++ b/roadmap.md
@@ -24,8 +24,8 @@ To provide a high-performance, zero-overhead, and platform-agnostic Enigma ciphe
     - Implement `install()` rules and export `EnigmaMachineCoreConfig.cmake` for `find_package`.
 - [ ] **Memory Profiling:**
     - Use `Valgrind`/`Sanitizers` to ensure zero leaks in the core library.
-- [ ] **Architecture Decision Records (ADRs):**
-    - Document core design choices (e.g., Signal path, DI strategy) in `docs/adr/`.
+- [x] **Architecture Decision Records (ADRs):**
+    - Document core design choices (e.g., Signal path, DI strategy) in [docs/adr/ADRs.md](docs/adr/ADRs.md).
 
 ## Phase 2: Universal Portability & PAL (Platform Abstraction Layer)
 **Goal:** Decouple from the OS and C++ Runtime (Exceptions/Filesystem).


### PR DESCRIPTION
## Description

What
- Created docs/adr/ADRs.md as the central index for design decisions.
- Created docs/adr/001-dependency-injection-for-assets.md documenting the IAssetProvider strategy.
- Created docs/adr/002-signal-path-strategy.md documenting the Alphabet Index vs. Raw Chars decision.
- Created docs/adr/003-error-handling-strategy.md documenting the transition to std::expected.
- Updated README.md and docs/Architecture.md to link to the new ADR repository.
- Updated roadmap.md to mark the ADR task as completed.

Why
- To index all architectural decisions in a single, accessible location for current and future contributors.
- Document Design Rationale: Provides a historical record of significant architectural choices to guide future development and porting efforts (Phase 2).
- Guidance for Universal Portability: Explicitly documents the context and consequences of critical decisions like no-exceptions compatibility and asset decoupling.
- Enhance Project Visibility: Ensures that new contributors and users can easily find the reasoning behind the project's structural patterns.
- To link the ADRs to the main documentation and roadmap, ensuring they are visible and accessible to all stakeholders.
- Track Progress: Marks the completion of a key milestone in the project's documentation and design process.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Tools update

## How Has This Been Validated?

No test needed

**Test Configuration**:
* Compiler/Toolchain:
* OS/Platform:

## Checklist:

- [ ] My code is documented with doxygen comments
- [ ] I have made corresponding changes to the documentation
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Additional Information

No additional information.

## Contributors

List of contributors to this pull request:
- @alvarocleite 
