### PR TITLE
Integrate Clang Sanitizers (ASan, UBSan, MSan)

### DIFF
--- a/.github/workflows/code-analysis.yml
+++ b/.github/workflows/code-analysis.yml
@@ -1,0 +1,14 @@
+name: Code Analysis
+
+on:
+  push:
+    branches: [ "main", "development" ]
+  pull_request:
+    branches: [ "main", "development" ]
+
+jobs:
+  static-analysis:
+    uses: ./.github/workflows/static-analysis.yml
+    
+  runtime-sanitizers:
+    uses: ./.github/workflows/sanitizers.yml

--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -1,10 +1,7 @@
 name: Sanitizers
 
 on:
-  push:
-    branches: [ "main", "development" ]
-  pull_request:
-    branches: [ "main", "development" ]
+  workflow_call:
 
 jobs:
   sanitize:

--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -1,0 +1,102 @@
+name: Sanitizers
+
+on:
+  push:
+    branches: [ "main", "development" ]
+  pull_request:
+    branches: [ "main", "development" ]
+
+jobs:
+  sanitize:
+    name: ${{ matrix.sanitizer }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - sanitizer: ASan
+            cmake_flag: -DENIGMA_USE_ASAN=ON
+          - sanitizer: UBSan
+            cmake_flag: -DENIGMA_USE_UBSAN=ON
+          - sanitizer: MSan
+            cmake_flag: -DENIGMA_USE_MSAN=ON
+
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        submodules: recursive
+
+    - name: Install Clang
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y clang llvm
+
+    - name: Configure CMake
+      run: |
+        cmake -B build \
+          -DCMAKE_CXX_COMPILER=clang++ \
+          -DCMAKE_C_COMPILER=clang \
+          -DCMAKE_BUILD_TYPE=Debug \
+          ${{ matrix.cmake_flag }} \
+          -DENIGMA_BUILD_CLI=ON \
+          -DENIGMA_BUILD_TESTS=OFF
+
+    - name: Build
+      run: cmake --build build
+
+    - name: Run Application (Sanitizer Check)
+      shell: bash
+      run: |
+        # Ensure assets are available in the current directory if needed
+        # (CMake already copies them to build/assets/ but app/main.cpp looks for "assets" locally first)
+        
+        # Scenario 1: Help
+        ./build/EnigmaMachineCore --help > /dev/null 2> sanitizer_help.log || true
+        
+        # Scenario 2: Simple encoding/decoding
+        # Note: app/main.cpp expects assetPath to contain Rotor1.toml etc.
+        ./build/EnigmaMachineCore -c build/assets/EnigmaMachineConfig1.toml -a build/assets/ -m "THEQUICKBROWNFOXJUMPSOVERTHELAZYDOG" --encode --decode > /dev/null 2> sanitizer_run.log || true
+        
+        # Scenario 3: Debug mode enabled
+        ./build/EnigmaMachineCore -c build/assets/EnigmaMachineConfig1.toml -a build/assets/ -m "ENIGMA" --debug > /dev/null 2> sanitizer_debug.log || true
+        
+        cat sanitizer_help.log sanitizer_run.log sanitizer_debug.log > sanitizer_all.log
+        echo "--- Sanitizer Output Log ---"
+        cat sanitizer_all.log
+
+    - name: Generate Sanitizer Summary
+      if: always()
+      shell: bash
+      run: |
+        # Count issues
+        ASAN_COUNT=$(grep -c "AddressSanitizer" sanitizer_all.log || echo 0)
+        UBSAN_COUNT=$(grep -c "runtime error:" sanitizer_all.log || echo 0)
+        MSAN_COUNT=$(grep -c "MemorySanitizer" sanitizer_all.log || echo 0)
+        TOTAL=$((ASAN_COUNT + UBSAN_COUNT + MSAN_COUNT))
+        
+        echo "## Sanitizer Report: ${{ matrix.sanitizer }}" >> $GITHUB_STEP_SUMMARY
+        echo "" >> $GITHUB_STEP_SUMMARY
+        echo "| Issue Type | Count |" >> $GITHUB_STEP_SUMMARY
+        echo "| :--- | :--- |" >> $GITHUB_STEP_SUMMARY
+        echo "| AddressSanitizer (ASan) | $ASAN_COUNT |" >> $GITHUB_STEP_SUMMARY
+        echo "| UndefinedBehavior (UBSan) | $UBSAN_COUNT |" >> $GITHUB_STEP_SUMMARY
+        echo "| MemorySanitizer (MSan) | $MSAN_COUNT |" >> $GITHUB_STEP_SUMMARY
+        echo "| **Total Issues** | **$TOTAL** |" >> $GITHUB_STEP_SUMMARY
+        echo "" >> $GITHUB_STEP_SUMMARY
+        
+        if [ $TOTAL -gt 0 ]; then
+          echo "⚠️ **Sanitizer detected $TOTAL issues.** Please review the build logs for details." >> $GITHUB_STEP_SUMMARY
+          echo "### Log Preview" >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+          head -n 30 sanitizer_all.log >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+        else
+          echo "✅ No issues detected by ${{ matrix.sanitizer }}." >> $GITHUB_STEP_SUMMARY
+        fi
+
+    - name: Upload Sanitizer Logs
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: sanitizer-logs-${{ matrix.sanitizer }}
+        path: sanitizer_all.log

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -1,10 +1,7 @@
 name: Static Analysis
 
 on:
-  push:
-    branches: [ "main", "development" ]
-  pull_request:
-    branches: [ "main", "development" ]
+  workflow_call:
 
 jobs:
   clang-tidy:

--- a/.sanitizer_ignorelist.txt
+++ b/.sanitizer_ignorelist.txt
@@ -1,0 +1,2 @@
+# Exclude external libraries from sanitizer instrumentation
+src:*/external/*

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,6 +66,10 @@ set(INCLUDE_DIRS
 # Initialize toml11 library (header-only submodule)
 add_subdirectory(external/toml11)
 
+# Ensure toml11 headers are treated as SYSTEM to suppress warnings and sanitizer noise
+get_target_property(TOML11_INCLUDE_DIRS toml11::toml11 INTERFACE_INCLUDE_DIRECTORIES)
+set_target_properties(toml11::toml11 PROPERTIES INTERFACE_SYSTEM_INCLUDE_DIRECTORIES "${TOML11_INCLUDE_DIRS}")
+
 # --- Core Targets ---
 
 # 1. Create Object Library for all core logic
@@ -147,6 +151,42 @@ if(ENIGMA_ENABLE_CLANG_TIDY)
     endif()
 endif()
 
+# --- Sanitizers ---
+option(ENIGMA_USE_ASAN "Enable AddressSanitizer" OFF)
+option(ENIGMA_USE_UBSAN "Enable UndefinedBehaviorSanitizer" OFF)
+option(ENIGMA_USE_MSAN "Enable MemorySanitizer (Clang only)" OFF)
+
+set(SANITIZER_FLAGS "")
+if(ENIGMA_USE_ASAN OR ENIGMA_USE_UBSAN OR ENIGMA_USE_MSAN)
+    if(NOT CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+        message(WARNING "Sanitizers are intended for use with Clang as per project requirements.")
+    endif()
+
+    # Sanitizer Ignore List (excludes external libraries from instrumentation)
+    set(IGNORE_LIST_FILE "${CMAKE_CURRENT_SOURCE_DIR}/.sanitizer_ignorelist.txt")
+    set(IGNORE_LIST_FLAG "-fsanitize-ignorelist=${IGNORE_LIST_FILE}")
+
+    if(ENIGMA_USE_ASAN)
+        list(APPEND SANITIZER_FLAGS "-fsanitize=address" "${IGNORE_LIST_FLAG}")
+    endif()
+    if(ENIGMA_USE_UBSAN)
+        list(APPEND SANITIZER_FLAGS "-fsanitize=undefined" "-fno-sanitize-recover=all" "${IGNORE_LIST_FLAG}")
+    endif()
+    if(ENIGMA_USE_MSAN)
+        list(APPEND SANITIZER_FLAGS "-fsanitize=memory" "-fsanitize-memory-track-origins" "-fno-omit-frame-pointer" "${IGNORE_LIST_FLAG}")
+    endif()
+
+    if(SANITIZER_FLAGS)
+        message(STATUS "Enabling Sanitizers: ${SANITIZER_FLAGS}")
+        
+        # Apply to core object library
+        target_compile_options(EnigmaCore_OBJ PRIVATE ${SANITIZER_FLAGS})
+        
+        # Apply to core library (linkage)
+        target_link_options(EnigmaCore PRIVATE ${SANITIZER_FLAGS})
+    endif()
+endif()
+
 # --- Main Executable Target ---
 if(ENIGMA_BUILD_CLI)
     # Application entry point
@@ -156,6 +196,10 @@ if(ENIGMA_BUILD_CLI)
 
     # Initialize and link CLI11 library (Only needed for the CLI app)
     add_subdirectory(external/CLI11)
+
+    # Ensure CLI11 headers are treated as SYSTEM
+    get_target_property(CLI11_INCLUDE_DIRS CLI11::CLI11 INTERFACE_INCLUDE_DIRECTORIES)
+    set_target_properties(CLI11::CLI11 PROPERTIES INTERFACE_SYSTEM_INCLUDE_DIRECTORIES "${CLI11_INCLUDE_DIRS}")
 
     # The EnigmaMachineCore application executable, which is just a wrapper around the EnigmaCore
     add_executable(${PROJECT_NAME}
@@ -167,6 +211,12 @@ if(ENIGMA_BUILD_CLI)
 
     # Link the core library logic to the executable
     target_link_libraries(${PROJECT_NAME} PRIVATE EnigmaMachineCore::EnigmaCore CLI11::CLI11)
+
+    # Apply sanitizers to CLI if enabled
+    if(SANITIZER_FLAGS)
+        target_compile_options(${PROJECT_NAME} PRIVATE ${SANITIZER_FLAGS})
+        target_link_options(${PROJECT_NAME} PRIVATE ${SANITIZER_FLAGS})
+    endif()
 
     # Define the installed assets path for the CLI fallback
     target_compile_definitions(${PROJECT_NAME} PRIVATE 
@@ -201,6 +251,24 @@ if(ENIGMA_BUILD_TESTS)
     FetchContent_MakeAvailable(googletest)
 
     enable_testing()
+
+    # Create a separate non-instrumented object library for tests if sanitizers are active
+    # to satisfy the requirement: "ensure these sanitizers do not run on the Unit Test suite targets"
+    if(SANITIZER_FLAGS)
+        add_library(EnigmaCore_NoSan_OBJ OBJECT ${CORE_SOURCES})
+        target_include_directories(EnigmaCore_NoSan_OBJ PUBLIC ${INCLUDE_DIRS})
+        target_link_libraries(EnigmaCore_NoSan_OBJ PUBLIC toml11::toml11)
+        set_target_properties(EnigmaCore_NoSan_OBJ PROPERTIES POSITION_INDEPENDENT_CODE ON)
+        target_compile_definitions(EnigmaCore_NoSan_OBJ PRIVATE 
+            ENIGMA_INSTALL_ASSETS_PATH="${CMAKE_INSTALL_FULL_DATADIR}/EnigmaMachineCore/assets/"
+        )
+        if(MSVC)
+            target_compile_options(EnigmaCore_NoSan_OBJ PRIVATE /W4)
+        else()
+            target_compile_options(EnigmaCore_NoSan_OBJ PRIVATE -Wall -Wextra -Wpedantic)
+        endif()
+    endif()
+
     add_subdirectory(tests)
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,8 +67,8 @@ set(INCLUDE_DIRS
 add_subdirectory(external/toml11)
 
 # Ensure toml11 headers are treated as SYSTEM to suppress warnings and sanitizer noise
-get_target_property(TOML11_INCLUDE_DIRS toml11::toml11 INTERFACE_INCLUDE_DIRECTORIES)
-set_target_properties(toml11::toml11 PROPERTIES INTERFACE_SYSTEM_INCLUDE_DIRECTORIES "${TOML11_INCLUDE_DIRS}")
+get_target_property(TOML11_INCLUDE_DIRS toml11 INTERFACE_INCLUDE_DIRECTORIES)
+set_target_properties(toml11 PROPERTIES INTERFACE_SYSTEM_INCLUDE_DIRECTORIES "${TOML11_INCLUDE_DIRS}")
 
 # --- Core Targets ---
 
@@ -198,8 +198,8 @@ if(ENIGMA_BUILD_CLI)
     add_subdirectory(external/CLI11)
 
     # Ensure CLI11 headers are treated as SYSTEM
-    get_target_property(CLI11_INCLUDE_DIRS CLI11::CLI11 INTERFACE_INCLUDE_DIRECTORIES)
-    set_target_properties(CLI11::CLI11 PROPERTIES INTERFACE_SYSTEM_INCLUDE_DIRECTORIES "${CLI11_INCLUDE_DIRS}")
+    get_target_property(CLI11_INCLUDE_DIRS CLI11 INTERFACE_INCLUDE_DIRECTORIES)
+    set_target_properties(CLI11 PROPERTIES INTERFACE_SYSTEM_INCLUDE_DIRECTORIES "${CLI11_INCLUDE_DIRS}")
 
     # The EnigmaMachineCore application executable, which is just a wrapper around the EnigmaCore
     add_executable(${PROJECT_NAME}

--- a/docs/Building.md
+++ b/docs/Building.md
@@ -13,6 +13,7 @@ To build and run this project, you will need the following tools and libraries:
 *   **Git:** Required for version control and to manage the project's submodules.
 *   **[clang-format](https://clang.llvm.org/docs/ClangFormat.html):** Recommended for maintaining consistent code style.
 *   **[clang-tidy](https://clang.llvm.org/extra/clang-tidy/):** Used for static analysis during the build process.
+*   **[LLVM/Clang Sanitizers](https://clang.llvm.org/docs/index.html):** Used for runtime analysis (ASan, UBSan, MSan). Requires `clang` and `llvm` (for `llvm-symbolizer`).
 
 ### Libraries
 *   **[toml11](https://github.com/ToruNiina/toml11):** A powerful C++11 header-only library for TOML.
@@ -199,6 +200,36 @@ Static analysis is performed using **clang-tidy** and is integrated into the CMa
 *   **Execution:** Once enabled, clang-tidy will run on every source file during compilation (`make`).
 *   **Identifying Issues:** Clang-tidy output is interleaved with compiler output. You can distinguish them by the bracketed check name at the end of the line (e.g., `[modernize-use-auto]`). Standard compiler warnings typically start with `-W`.
 *   **Configuration:** The list of active checks is defined in `CMakeLists.txt`.
+
+---
+
+## Sanitizers (Runtime Analysis)
+
+The project supports LLVM/Clang Sanitizers to detect memory errors, uninitialized reads, and undefined behavior at runtime.
+
+### Requirements
+*   **Compiler:** Requires `clang` / `clang++`.
+*   **Tools:** `llvm` (specifically `llvm-symbolizer`) is recommended for descriptive backtraces.
+
+### Available Options
+| Option | Sanitizer |
+| :--- | :--- |
+| `ENIGMA_USE_ASAN` | AddressSanitizer (ASan) |
+| `ENIGMA_USE_UBSAN` | UndefinedBehaviorSanitizer (UBSan) |
+| `ENIGMA_USE_MSAN` | MemorySanitizer (MSan) |
+
+### Usage
+1.  **Configure with Clang and Sanitizers:**
+    ```bash
+    cmake -DCMAKE_CXX_COMPILER=clang++ -DENIGMA_USE_ASAN=ON -S . -B build
+    ```
+2.  **Build and Run:**
+    ```bash
+    cmake --build build
+    ./scripts/run_sanitizers.sh build
+    ```
+
+*Note: Sanitizers are automatically excluded from the Unit Test suite to maintain performance. They are applied to the core engine and CLI application.*
 
 ---
 

--- a/docs/Building.md
+++ b/docs/Building.md
@@ -229,7 +229,7 @@ The project supports LLVM/Clang Sanitizers to detect memory errors, uninitialize
     ./scripts/run_sanitizers.sh build
     ```
 
-*Note: Sanitizers are automatically excluded from the Unit Test suite to maintain performance. They are applied to the core engine and CLI application.*
+*Note: Sanitizers are automatically excluded from the Unit Test suite to maintain performance. They are applied to the core engine and CLI application. In CI, these checks are centralized in the `code-analysis.yml` workflow.*
 
 ---
 

--- a/docs/Testing.md
+++ b/docs/Testing.md
@@ -88,6 +88,42 @@ add_executable(EnigmaTests
 ### 3. Build and Run
 Re-run your build command. CMake will automatically detect the new tests.
 
+## Sanitizers (Clang)
+
+To improve code reliability and detect memory errors or undefined behavior, the project integrates LLVM/Clang Sanitizers.
+
+### Requirements
+*   **Compiler:** `clang` / `clang++` must be used for sanitizer builds.
+
+### Enabling Sanitizers
+You can enable sanitizers individually during the CMake configuration step:
+
+| Option | Sanitizer | Description |
+| :--- | :--- | :--- |
+| `ENIGMA_USE_ASAN` | AddressSanitizer (ASan) | Detects heap/stack buffer overflows, use-after-free, and memory leaks. |
+| `ENIGMA_USE_UBSAN` | UndefinedBehaviorSanitizer (UBSan) | Detects signed integer overflow, null pointer dereference, and other C++ undefined behaviors. |
+| `ENIGMA_USE_MSAN` | MemorySanitizer (MSan) | Detects uninitialized memory reads. |
+
+**Example Command:**
+```bash
+cmake -DCMAKE_CXX_COMPILER=clang++ -DENIGMA_USE_ASAN=ON -B build
+cmake --build build
+```
+
+### Local Verification
+To run the same scenarios as the CI locally, use the provided helper script:
+```bash
+# Ensure you have built the CLI with sanitizers enabled
+./scripts/run_sanitizers.sh build
+```
+
+### Constraints
+*   **Exclusion of Tests:** By design, sanitizers are applied to the core engine and the CLI application but are **excluded** from the Unit Test suite targets. This is achieved by using a separate non-instrumented object library for tests when sanitizers are active, reducing noise and execution time for the test suite.
+*   **Performance:** Sanitizers introduce runtime overhead (typically 2x-4x) and should be used during development or in specific CI pipelines rather than production builds.
+
+### CI Integration
+A dedicated GitHub Actions workflow (`sanitizers.yml`) runs on every push and pull request. It performs a build with each sanitizer enabled and runs the application through multiple scenarios. Results are reported in the **GitHub Job Summary** without failing the build, allowing the team to monitor and fix issues asynchronously.
+
 ## GoogleTest Dependency
 The project uses CMake's `FetchContent` to download GoogleTest automatically.
 *   **Offline Mode:** You must run the initial CMake configuration while online. After that, the library is stored in `build/<build_type>/_deps` and can be used offline.

--- a/docs/Testing.md
+++ b/docs/Testing.md
@@ -122,7 +122,11 @@ To run the same scenarios as the CI locally, use the provided helper script:
 *   **Performance:** Sanitizers introduce runtime overhead (typically 2x-4x) and should be used during development or in specific CI pipelines rather than production builds.
 
 ### CI Integration
-A dedicated GitHub Actions workflow (`sanitizers.yml`) runs on every push and pull request. It performs a build with each sanitizer enabled and runs the application through multiple scenarios. Results are reported in the **GitHub Job Summary** without failing the build, allowing the team to monitor and fix issues asynchronously.
+Code analysis is centralized in the **Code Analysis** workflow (`code-analysis.yml`), which runs on every push and pull request. It orchestrates parallel jobs for:
+*   **Static Analysis:** Running Clang-Tidy on the core logic.
+*   **Runtime Sanitizers:** Executing ASan, UBSan, and MSan checks via the reusable `sanitizers.yml` workflow.
+
+Results are aggregated into a single **GitHub Job Summary** without failing the build, allowing the team to monitor and fix issues asynchronously.
 
 ## GoogleTest Dependency
 The project uses CMake's `FetchContent` to download GoogleTest automatically.

--- a/scripts/run_sanitizers.sh
+++ b/scripts/run_sanitizers.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+set -e
+
+# Helper script to run EnigmaMachineCore through common scenarios 
+# for sanitizer verification (ASan, UBSan, MSan).
+
+BUILD_DIR=${1:-build}
+APP_BIN="$BUILD_DIR/EnigmaMachineCore"
+ASSETS_DIR="$BUILD_DIR/assets"
+CONFIG_FILE="$ASSETS_DIR/EnigmaMachineConfig1.toml"
+
+if [ ! -f "$APP_BIN" ]; then
+    echo "Error: EnigmaMachineCore binary not found in $BUILD_DIR"
+    echo "Usage: ./scripts/run_sanitizers.sh [build_directory]"
+    exit 1
+fi
+
+echo "--- Starting Sanitizer Check ---"
+
+# Scenario 1: Help
+echo "[Scenario 1] Running --help..."
+$APP_BIN --help > /dev/null
+
+# Scenario 2: Simple encoding/decoding
+echo "[Scenario 2] Encoding and decoding message..."
+$APP_BIN -c "$CONFIG_FILE" -a "$ASSETS_DIR" -m "THEQUICKBROWNFOXJUMPSOVERTHELAZYDOG" --encode --decode > /dev/null
+
+# Scenario 3: Debug mode enabled
+echo "[Scenario 3] Running in debug mode..."
+$APP_BIN -c "$CONFIG_FILE" -a "$ASSETS_DIR" -m "ENIGMA" --debug > /dev/null
+
+echo "--- Sanitizer Check Completed Successfully ---"
+echo "If no output was produced above (other than scenario messages), no issues were detected."

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -12,7 +12,11 @@ add_executable(EnigmaTests
 
 # Link against the Core Logic (Object Library) and GTest
 # Linking against the OBJ library allows access to hidden internal symbols
-target_link_libraries(EnigmaTests PRIVATE EnigmaCore_OBJ GTest::gtest_main)
+if(TARGET EnigmaCore_NoSan_OBJ)
+    target_link_libraries(EnigmaTests PRIVATE EnigmaCore_NoSan_OBJ GTest::gtest_main)
+else()
+    target_link_libraries(EnigmaTests PRIVATE EnigmaCore_OBJ GTest::gtest_main)
+endif()
 
 # Register tests so CTest can find them
 include(GoogleTest)


### PR DESCRIPTION
## Description

Implement LLVM/Clang Sanitizers to improve code reliability and detect runtime errors, fulfilling Issue #45.

Changes:
- Add ENIGMA_USE_ASAN, ENIGMA_USE_UBSAN, and ENIGMA_USE_MSAN CMake options.
- Configure separate non-instrumented EnigmaCore_NoSan_OBJ target to ensure unit tests remain uninstrumented for better performance.
- Create .github/workflows/sanitizers.yml for automated matrix testing with non-blocking Job Summary reporting and artifact logging.
- Add .sanitizer_ignorelist.txt and set SYSTEM includes for external libraries (toml11, CLI11) to suppress noise.
- Provide scripts/run_sanitizers.sh for local developer verification.
- Update docs/Building.md and docs/Testing.md with tool requirements and usage instructions.

Addresses: Issue #45 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional changes, no api changes)
- [x] Tools update

## How Has This Been Validated?

By running locally. 

**Test Configuration**:
* Compiler/Toolchain: Clang
* OS/Platform: Linux

## Checklist:

- [x] My code is documented with doxygen comments
- [x] I have made corresponding changes to the documentation
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Additional Information

No additional information.

## Contributors

List of contributors to this pull request:
- @alvarocleite 
