### PR TITLE
optimize initialization and reduce heap allocations

### DIFF
--- a/EnigmaMachine/include/EnigmaMachine.hpp
+++ b/EnigmaMachine/include/EnigmaMachine.hpp
@@ -35,6 +35,13 @@ protected:
      */
     explicit EnigmaMachine(const EnigmaMachineConfig& config, ILogger* logger = nullptr);
 
+    /**
+     * @brief Internal constructor using the configuration struct (move version).
+     * @param config The machine configuration.
+     * @param logger Optional logger for event reporting.
+     */
+    explicit EnigmaMachine(EnigmaMachineConfig&& config, ILogger* logger = nullptr);
+
 private:
     std::unique_ptr<RotorBox> rotorBox;
     std::unique_ptr<PlugBoard> plugBoard;

--- a/EnigmaMachine/include/EnigmaMachineConfig.hpp
+++ b/EnigmaMachine/include/EnigmaMachineConfig.hpp
@@ -15,7 +15,7 @@ struct RotorConfig {
     /** @brief The position (0 - (TRANSFORMER_SIZE - 1)) at which the rotor triggers the turnover of the next rotor. */
     AlphabetIndex notchPosition = 0;
     /** @brief The internal wiring permutation array (forward direction). Must be of size TRANSFORMER_SIZE. */
-    std::vector<AlphabetIndex> wiring;
+    std::array<AlphabetIndex, TRANSFORMER_SIZE> wiring;
 };
 
 /**
@@ -24,7 +24,7 @@ struct RotorConfig {
 struct ReflectorConfig {
     ReflectorConfig();
     /** @brief The internal wiring permutation array (reflection map). Must be of size TRANSFORMER_SIZE. */
-    std::vector<AlphabetIndex> wiring;
+    std::array<AlphabetIndex, TRANSFORMER_SIZE> wiring;
 };
 
 /**

--- a/EnigmaMachine/src/EnigmaConfigLoader.cpp
+++ b/EnigmaMachine/src/EnigmaConfigLoader.cpp
@@ -38,17 +38,13 @@ void validateTransformerConfig(const toml::value& data, const std::string& expec
 
 RotorConfig EnigmaConfigLoader::loadRotor(const IAssetProvider& provider, const FileName& fileName) {
     std::istringstream stream(provider.loadAsset(fileName.string()));
-    // Parse from stream, pass filename for error reporting
     auto rotorData = toml::parse(stream, fileName.string());
     validateTransformerConfig(rotorData, "rotor", fileName.string());
 
     RotorConfig rotorConfig;
     rotorConfig.notchPosition = toml::find<AlphabetIndex>(rotorData, "rotor", "notchPosition");
-    rotorConfig.wiring = toml::find<std::vector<AlphabetIndex>>(rotorData, "rotor", "forward");
+    rotorConfig.wiring = toml::find<std::array<AlphabetIndex, TRANSFORMER_SIZE>>(rotorData, "rotor", "forward");
 
-    if (rotorConfig.wiring.size() != TRANSFORMER_SIZE) {
-        throw std::runtime_error("Error: Rotor wiring size mismatch in " + fileName.string());
-    }
     return rotorConfig;
 }
 
@@ -58,10 +54,7 @@ ReflectorConfig EnigmaConfigLoader::loadReflector(const IAssetProvider& provider
     validateTransformerConfig(reflectorData, "reflector", fileName.string());
 
     ReflectorConfig reflectorConfig;
-    reflectorConfig.wiring = toml::find<std::vector<AlphabetIndex>>(reflectorData, "reflector", "map");
-    if (reflectorConfig.wiring.size() != TRANSFORMER_SIZE) {
-        throw std::runtime_error("Error: Reflector wiring size mismatch in " + fileName.string());
-    }
+    reflectorConfig.wiring = toml::find<std::array<AlphabetIndex, TRANSFORMER_SIZE>>(reflectorData, "reflector", "map");
     return reflectorConfig;
 }
 
@@ -71,8 +64,7 @@ EnigmaMachineConfig EnigmaConfigLoader::load(const IAssetProvider& provider, con
     auto data = toml::parse(stream, fileName.string());
 
     int rotorCount = toml::find<int>(data, "rotors", "RotorCount");
-    std::vector<AlphabetIndex> rotorPositions =
-        toml::find<std::vector<AlphabetIndex>>(data, "rotors", "RotorPositions");
+    auto rotorPositions = toml::find<std::vector<AlphabetIndex>>(data, "rotors", "RotorPositions");
     auto rotorFilePaths = toml::find<std::vector<std::string>>(data, "rotors", "RotorFiles");
 
     if (static_cast<size_t>(rotorCount) != rotorPositions.size() ||
@@ -106,8 +98,8 @@ EnigmaMachineConfig EnigmaConfigLoader::load(const IAssetProvider& provider, con
 
     EnigmaMachineConfig newConfig;
     newConfig.rotorCount = rotorCount;
-    newConfig.rotorPositions = rotorPositions;
-    newConfig.rotors = rotors;
+    newConfig.rotorPositions = std::move(rotorPositions);
+    newConfig.rotors = std::move(rotors);
     newConfig.reflector = reflector;
     newConfig.plugBoardPairs = plugBoardPairs;
 

--- a/EnigmaMachine/src/EnigmaMachine.cpp
+++ b/EnigmaMachine/src/EnigmaMachine.cpp
@@ -78,6 +78,14 @@ EnigmaMachine::EnigmaMachine(const EnigmaMachineConfig& config, ILogger* logger)
     rotorBox->registerObserver(this);
 }
 
+EnigmaMachine::EnigmaMachine(EnigmaMachineConfig&& config, ILogger* logger)
+    : rotorBox(std::make_unique<RotorBox>(std::move(config.rotorPositions), std::move(config.rotors),
+                                          std::move(config.reflector), logger)),
+      plugBoard(std::make_unique<PlugBoard>(config.plugBoardPairs)),
+      logger(logger) {
+    rotorBox->registerObserver(this);
+}
+
 EnigmaMachine::EnigmaMachine(std::string_view fileName, std::string_view assetPath, ILogger* logger)
     : EnigmaMachine(FileAssetProvider{}, fileName, assetPath, logger) {}
 
@@ -143,7 +151,7 @@ void EnigmaMachine::setLogger(ILogger* log) {
 void EnigmaMachine::registerObserver(IEnigmaObserver* observer) { observers.push_back(observer); }
 
 void EnigmaMachine::removeObserver(IEnigmaObserver* observer) {
-    auto iterator = std::remove(observers.begin(), observers.end(), observer);
+    auto iterator = std::ranges::remove(observers, observer).begin();
     if (iterator != observers.end()) {
         observers.erase(iterator, observers.end());
     }

--- a/EnigmaMachine/src/EnigmaMachineConfig.cpp
+++ b/EnigmaMachine/src/EnigmaMachineConfig.cpp
@@ -7,9 +7,7 @@
 
 #include <numeric>
 
-RotorConfig::RotorConfig() {
-    std::iota(wiring.begin(), wiring.end(), 0);
-}
+RotorConfig::RotorConfig() { std::iota(wiring.begin(), wiring.end(), 0); }
 
 ReflectorConfig::ReflectorConfig() {
     for (int i = 0; i < TRANSFORMER_SIZE; ++i) {

--- a/EnigmaMachine/src/EnigmaMachineConfig.cpp
+++ b/EnigmaMachine/src/EnigmaMachineConfig.cpp
@@ -8,12 +8,10 @@
 #include <numeric>
 
 RotorConfig::RotorConfig() {
-    wiring.resize(TRANSFORMER_SIZE);
     std::iota(wiring.begin(), wiring.end(), 0);
 }
 
 ReflectorConfig::ReflectorConfig() {
-    wiring.resize(TRANSFORMER_SIZE);
     for (int i = 0; i < TRANSFORMER_SIZE; ++i) {
         wiring[i] = TRANSFORMER_SIZE - 1 - i;
     }

--- a/RotorBox/include/Reflector.hpp
+++ b/RotorBox/include/Reflector.hpp
@@ -24,6 +24,7 @@ public:
      * @param config The ReflectorConfig structure containing the wiring map.
      */
     explicit Reflector(const ReflectorConfig& config);
+    explicit Reflector(ReflectorConfig&& config);
     ~Reflector() override = default;
 
     /**

--- a/RotorBox/include/Rotor.hpp
+++ b/RotorBox/include/Rotor.hpp
@@ -42,6 +42,7 @@ public:
      * @param config The RotorConfig structure containing wiring and notch info.
      */
     explicit Rotor(const RotorConfig& config);
+    explicit Rotor(RotorConfig&& config);
     ~Rotor() override = default;
 
     /**

--- a/RotorBox/include/RotorBox.hpp
+++ b/RotorBox/include/RotorBox.hpp
@@ -63,6 +63,16 @@ public:
     RotorBox(const std::vector<AlphabetIndex>& rotorPositions, const std::vector<RotorConfig>& rotors,
              const ReflectorConfig& reflector, ILogger* logger = nullptr);
 
+    /**
+     * @brief Constructor for the RotorBox class (move version).
+     * @param rotorPositions A vector containing the initial positions of each rotor.
+     * @param rotors A vector containing the configuration for each rotor.
+     * @param reflector Configuration for the reflector.
+     * @param logger Optional logger for event reporting.
+     */
+    RotorBox(std::vector<AlphabetIndex>&& rotorPositions, std::vector<RotorConfig>&& rotors,
+             ReflectorConfig&& reflector, ILogger* logger = nullptr);
+
     // Disable Copy
     RotorBox(const RotorBox&) = delete;
     RotorBox& operator=(const RotorBox&) = delete;

--- a/RotorBox/include/Transformer.hpp
+++ b/RotorBox/include/Transformer.hpp
@@ -55,6 +55,14 @@ protected:
     void fillTransformRow(int row, AlphabetIndex value);
 
     /**
+     * @brief Copies a whole array into a row of the transformation lookup table.
+     *
+     * @param row The row index to copy into.
+     * @param values The array of values to copy.
+     */
+    void copyTransformRow(int row, const std::array<AlphabetIndex, TRANSFORMER_SIZE>& values);
+
+    /**
      * @brief Gets a read-only reference to a row in the transformation lookup table.
      * Useful for using standard algorithms like std::find.
      *

--- a/RotorBox/src/Reflector.cpp
+++ b/RotorBox/src/Reflector.cpp
@@ -11,18 +11,20 @@
 Reflector::Reflector(const ReflectorConfig& config) {
     type = TransformerType::Reflector;
 
-    if (config.wiring.size() != TRANSFORMER_SIZE) {
-        throw std::runtime_error("Reflector wiring size mismatch");
-    }
-
-    for (size_t i = 0; i < config.wiring.size(); ++i) {
-        setTransformValue(0, static_cast<int>(i), config.wiring[i]);
-    }
+    copyTransformRow(0, config.wiring);
 
     // Initialize reverse transformation vector to -1.
     // Reflectors are typically symmetric, but the Transformer base class supports separate reverse path.
     // For a reflector, the return path is usually implicit in the map itself if symmetric.
     // However, keeping consistent with the old code:
+    fillTransformRow(1, -1);
+}
+
+Reflector::Reflector(ReflectorConfig&& config) {
+    type = TransformerType::Reflector;
+
+    copyTransformRow(0, config.wiring);
+
     fillTransformRow(1, -1);
 }
 

--- a/RotorBox/src/Rotor.cpp
+++ b/RotorBox/src/Rotor.cpp
@@ -24,14 +24,18 @@ Rotor::Rotor(const RotorConfig& config) {
     rotationCount = 0;
     type = TransformerType::Rotor;
 
-    // Set forward wiring from config
-    if (config.wiring.size() != TRANSFORMER_SIZE) {
-        throw std::runtime_error("Rotor wiring size mismatch");
-    }
+    copyTransformRow(0, config.wiring);
 
-    for (size_t i = 0; i < config.wiring.size(); ++i) {
-        setTransformValue(0, static_cast<int>(i), config.wiring[i]);
-    }
+    initReverseLookupTable();
+    initRotorPosition();
+}
+
+Rotor::Rotor(RotorConfig&& config) {
+    notchPosition = config.notchPosition;
+    rotationCount = 0;
+    type = TransformerType::Rotor;
+
+    copyTransformRow(0, config.wiring);
 
     initReverseLookupTable();
     initRotorPosition();

--- a/RotorBox/src/RotorBox.cpp
+++ b/RotorBox/src/RotorBox.cpp
@@ -40,22 +40,38 @@ RotorBox::RotorBox(const std::vector<AlphabetIndex>& rotorPositions, const std::
     }
 
     rotorCount = (int)rotorPositions.size();
-    this->rotorPositions.reserve(rotorCount);
-    for (const auto& position : rotorPositions) {
-        this->rotorPositions.push_back(position);
-    }
+    this->rotorPositions = rotorPositions;
 
     initTransformers(rotors, reflector);
 
     for (int i = 0; i < rotorCount; i++) {
-        transformers.at(i)->setPosition(rotorPositions.at(i));
+        transformers.at(i)->setPosition(this->rotorPositions.at(i));
+    }
+}
+
+RotorBox::RotorBox(std::vector<AlphabetIndex>&& rotorPositions, std::vector<RotorConfig>&& rotors,
+                   ReflectorConfig&& reflector, ILogger* logger)
+    : rotorCount((int)rotorPositions.size()), rotorPositions(std::move(rotorPositions)), logger(logger) {
+    if (std::cmp_not_equal(this->rotorPositions.size(), rotors.size())) {
+        throw std::invalid_argument("Error: Number of rotors and number of rotor positions do not match.");
+    }
+
+    // Optimization: avoid copying configs by moving them into the transformers
+    transformers.reserve(rotorCount + 1);
+    for (auto& rotorConfig : rotors) {
+        transformers.push_back(std::make_unique<Rotor>(std::move(rotorConfig)));
+    }
+    transformers.push_back(std::make_unique<Reflector>(std::move(reflector)));
+
+    for (int i = 0; i < rotorCount; i++) {
+        transformers.at(i)->setPosition(this->rotorPositions.at(i));
     }
 }
 
 void RotorBox::registerObserver(IEnigmaObserver* observer) { observers.push_back(observer); }
 
 void RotorBox::removeObserver(IEnigmaObserver* observer) {
-    auto iterator = std::remove(observers.begin(), observers.end(), observer);
+    auto iterator = std::ranges::remove(observers, observer).begin();
     observers.erase(iterator, observers.end());
 }
 
@@ -70,8 +86,9 @@ void RotorBox::initTransformers(const std::vector<RotorConfig>& rotors, const Re
     transformers.clear();
     transformers.reserve(rotorCount + 1);
 
-    std::ranges::transform(rotors, std::back_inserter(transformers),
-                           [](const auto& rotorConfig) { return std::make_unique<Rotor>(rotorConfig); });
+    for (const auto& rotorConfig : rotors) {
+        transformers.push_back(std::make_unique<Rotor>(rotorConfig));
+    }
     transformers.emplace_back(std::make_unique<Reflector>(reflector));
 }
 

--- a/RotorBox/src/Transformer.cpp
+++ b/RotorBox/src/Transformer.cpp
@@ -33,6 +33,13 @@ AlphabetIndex Transformer::getTransformValue(int row, int col) const { return lo
 void Transformer::fillTransformRow(int row, AlphabetIndex value) { lookupTable.at(row).fill(value); }
 
 /**
+ * @brief Copies a whole array into a row of the transformation lookup table.
+ */
+void Transformer::copyTransformRow(int row, const std::array<AlphabetIndex, TRANSFORMER_SIZE>& values) {
+    lookupTable.at(row) = values;
+}
+
+/**
  * @brief Gets a read-only reference to a row in the transformation lookup table.
  */
 const std::array<AlphabetIndex, TRANSFORMER_SIZE>& Transformer::getTransformRow(int row) const {

--- a/benchmarks/EnigmaBenchmark.cpp
+++ b/benchmarks/EnigmaBenchmark.cpp
@@ -136,13 +136,13 @@ static void BM_EnigmaMachine_Throughput_Scaling(benchmark::State& state) {
     config.rotors.resize(nRotors);
     
     // Shared wiring for all rotors for simplicity
-    std::vector<int> wiring = {1, 3, 5, 7, 9, 11, 13, 15, 17, 19, 21, 23, 25, 0, 2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22, 24};
+    std::array<int, TRANSFORMER_SIZE> wiring = {{1, 3, 5, 7, 9, 11, 13, 15, 17, 19, 21, 23, 25, 0, 2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22, 24}};
     for(int i = 0; i < nRotors; ++i) {
         config.rotors[i].wiring = wiring;
         config.rotors[i].notchPosition = 16;
     }
     
-    config.reflector.wiring = {25, 24, 23, 22, 21, 20, 19, 18, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0};
+    config.reflector.wiring = {{25, 24, 23, 22, 21, 20, 19, 18, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0}};
     
     BenchmarkingEnigmaMachine machine(config);
     
@@ -172,12 +172,12 @@ static void BM_EnigmaMachine_PlugBoard_Scaling(benchmark::State& state) {
     config.rotorPositions = {0, 0, 0};
     config.rotors.resize(3);
     
-    std::vector<int> wiring = {1, 3, 5, 7, 9, 11, 13, 15, 17, 19, 21, 23, 25, 0, 2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22, 24};
+    std::array<int, TRANSFORMER_SIZE> wiring = {{1, 3, 5, 7, 9, 11, 13, 15, 17, 19, 21, 23, 25, 0, 2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22, 24}};
     for(int i = 0; i < 3; ++i) {
         config.rotors[i].wiring = wiring;
         config.rotors[i].notchPosition = 16;
     }
-    config.reflector.wiring = {25, 24, 23, 22, 21, 20, 19, 18, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0};
+    config.reflector.wiring = {{25, 24, 23, 22, 21, 20, 19, 18, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0}};
     
     // Fill with nSwaps
     for(int i = 0; i < nSwaps; ++i) {
@@ -228,7 +228,7 @@ BENCHMARK(BM_EnigmaMachine_KeyTransform)->Range(KB, 128 * KB);
 static void BM_Rotor_Transform(benchmark::State& state) {
     // Manually create a rotor config for benchmarking
     RotorConfig config;
-    config.wiring = {1, 3, 5, 7, 9, 11, 13, 15, 17, 19, 21, 23, 25, 0, 2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22, 24};
+    config.wiring = {{1, 3, 5, 7, 9, 11, 13, 15, 17, 19, 21, 23, 25, 0, 2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22, 24}};
     config.notchPosition = 16;
     
     Rotor rotor(config);
@@ -245,7 +245,7 @@ BENCHMARK(BM_Rotor_Transform);
 
 static void BM_Rotor_Rotate(benchmark::State& state) {
     RotorConfig config;
-    config.wiring = {1, 3, 5, 7, 9, 11, 13, 15, 17, 19, 21, 23, 25, 0, 2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22, 24};
+    config.wiring = {{1, 3, 5, 7, 9, 11, 13, 15, 17, 19, 21, 23, 25, 0, 2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22, 24}};
     config.notchPosition = 16;
     Rotor rotor(config);
 
@@ -258,7 +258,7 @@ BENCHMARK(BM_Rotor_Rotate);
 
 static void BM_Reflector_Transform(benchmark::State& state) {
     ReflectorConfig config;
-    config.wiring = {25, 24, 23, 22, 21, 20, 19, 18, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0};
+    config.wiring = {{25, 24, 23, 22, 21, 20, 19, 18, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0}};
     Reflector reflector(config);
 
     int input = 0;

--- a/docs/diagrams/class_diagram.puml
+++ b/docs/diagrams/class_diagram.puml
@@ -19,11 +19,11 @@ class PlugBoardPair <<struct>> {
 
 class RotorConfig <<struct>> {
     + AlphabetIndex notchPosition
-    + std::vector<AlphabetIndex> wiring
+    + std::array<AlphabetIndex, TRANSFORMER_SIZE> wiring
 }
 
 class ReflectorConfig <<struct>> {
-    + std::vector<AlphabetIndex> wiring
+    + std::array<AlphabetIndex, TRANSFORMER_SIZE> wiring
 }
 
 ' Interfaces
@@ -65,7 +65,8 @@ class EnigmaMachine {
     - plugBoard : std::unique_ptr<PlugBoard>
     - observers : std::vector<IEnigmaObserver*>
     - logger : ILogger*
-    # EnigmaMachine(config: EnigmaMachineConfig)
+    # EnigmaMachine(config: const EnigmaMachineConfig&)
+    # EnigmaMachine(config: EnigmaMachineConfig&&)
     + EnigmaMachine(logger: ILogger* = nullptr)
     + EnigmaMachine(fileName: std::string_view, assetPath: std::string_view, logger: ILogger* = nullptr)
     + EnigmaMachine(provider: IAssetProvider, fileName: std::string_view, assetPath: std::string_view, logger: ILogger* = nullptr)
@@ -93,10 +94,11 @@ class RotorBox {
     - transformers : std::vector<std::unique_ptr<Transformer>>
     - observers : std::vector<IEnigmaObserver*>
     - logger : ILogger*
-    - initTransformers(rotors: std::vector<RotorConfig>, reflector: ReflectorConfig) : void
+    - initTransformers(rotors: const std::vector<RotorConfig>&, reflector: const ReflectorConfig&) : void
     - updateRotors() : void
     + RotorBox(logger: ILogger* = nullptr)
-    + RotorBox(rotorPositions: std::vector<AlphabetIndex>, rotors: std::vector<RotorConfig>, reflector: ReflectorConfig, logger: ILogger* = nullptr)
+    + RotorBox(rotorPositions: const std::vector<AlphabetIndex>&, rotors: const std::vector<RotorConfig>&, reflector: const ReflectorConfig&, logger: ILogger* = nullptr)
+    + RotorBox(rotorPositions: std::vector<AlphabetIndex>&&, rotors: std::vector<RotorConfig>&&, reflector: ReflectorConfig&&, logger: ILogger* = nullptr)
     + ~RotorBox()
     + printTransformers() : void
     + keyTransform(input: AlphabetIndex) : AlphabetIndex
@@ -110,6 +112,7 @@ abstract class Transformer {
     # setTransformValue(row: int, col: int, value: AlphabetIndex) : void
     # getTransformValue(row: int, col: int) : AlphabetIndex
     # fillTransformRow(row: int, value: AlphabetIndex) : void
+    # copyTransformRow(row: int, values: const std::array<AlphabetIndex, TRANSFORMER_SIZE>&) : void
     # getTransformRow(row: int) : const std::array<AlphabetIndex, TRANSFORMER_SIZE>&
     + Transformer()
     + {abstract} ~Transformer()
@@ -128,7 +131,8 @@ class Rotor {
     - rotationCount : AlphabetIndex
     - initReverseLookupTable() : void
     + isNotchPosition(position: AlphabetIndex) : bool
-    + Rotor(config: RotorConfig)
+    + Rotor(config: const RotorConfig&)
+    + Rotor(config: RotorConfig&&)
     + ~Rotor()
     + transform(position: AlphabetIndex, reverse: bool) : AlphabetIndex
     + transformForward(position: AlphabetIndex) : AlphabetIndex
@@ -139,7 +143,8 @@ class Rotor {
 }
 
 class Reflector {
-    + Reflector(config: ReflectorConfig)
+    + Reflector(config: const ReflectorConfig&)
+    + Reflector(config: ReflectorConfig&&)
     + ~Reflector()
     + transform(position: AlphabetIndex, reverse: bool) : AlphabetIndex
     + transformForward(position: AlphabetIndex) : AlphabetIndex


### PR DESCRIPTION
## Description

- Replace 'std::vector' with 'std::array' for rotor/reflector wiring to eliminate redundant heap allocations.
- Implement move-aware constructors for 'EnigmaMachine', 'RotorBox', 'Rotor', and 'Reflector' to avoid unnecessary data copies.
- Introduce 'Transformer::copyTransformRow' for efficient lookup table population.
- Optimize 'EnigmaConfigLoader' to use move semantics and direct 'std::array' parsing.
- Update benchmarks to reflect architectural changes and confirm performance gains.
- Align class diagram documentation with the optimized move-based initialization flow.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Refactoring (no functional changes, no api changes)
- [ ] Tools update

## How Has This Been Validated?

Run test localy.

**Test Configuration**:
* Compiler/Toolchain: GCC and CMake
* OS/Platform: Linux

## Checklist:

- [x] My code is documented with doxygen comments
- [x] I have made corresponding changes to the documentation
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Additional Information

No additional information.

## Contributors

List of contributors to this pull request:
- @alvarocleite 
