### PR TITLE
Add PlantUML visualizations for Enigma mechanics

### DIFF
--- a/EnigmaMachine/include/EnigmaMachine.hpp
+++ b/EnigmaMachine/include/EnigmaMachine.hpp
@@ -22,6 +22,9 @@ class IAssetProvider;
 
 /**
  * @brief Class representing the Enigma machine.
+ *
+ * @image html signal-flow.svg "Complete Signal Flow" width=1000px
+ *
  * This class encapsulates the functionality of the Enigma machine, providing a simple
  * interface for encryption while hiding the complexity of the rotors and plugboard.
  */

--- a/PlugBoard/include/PlugBoard.hpp
+++ b/PlugBoard/include/PlugBoard.hpp
@@ -11,6 +11,14 @@
 #include "PlugBoardPair.hpp"
 #include "config.hpp"
 
+/**
+ * @brief Class representing the PlugBoard (Steckerbrett) of the Enigma machine.
+ *
+ * @image html plugboard-structure.svg "PlugBoard Structure" width=600px
+ *
+ * The plugboard allows for manual swapping of letter pairs before they enter
+ * the rotor assembly and after they exit.
+ */
 class PlugBoard {
 private:
     std::array<AlphabetIndex, TRANSFORMER_SIZE> mapping;  // Direct mapping: mapping[Input] = Output

--- a/README.md
+++ b/README.md
@@ -123,6 +123,9 @@ For more details on performance metrics and benchmarking options, see [docs/Benc
 
 If you have Doxygen installed, you can generate the project documentation.
 
+*   **Internal Workings:** See [docs/EnigmaMachineWorkings.md](docs/EnigmaMachineWorkings.md) for a technical explanation of the Enigma simulation and signal flow diagrams.
+*   **API Reference:** Generate with Doxygen (see below).
+
 **Using the modern CMake CLI:**
 ```bash
 cmake --build build --target Enigma_doxygen

--- a/RotorBox/include/RotorBox.hpp
+++ b/RotorBox/include/RotorBox.hpp
@@ -15,6 +15,9 @@
 
 /**
  * @brief Class representing a box of rotors in the Enigma machine.
+ *
+ * @image html rotorbox-organization.svg "RotorBox Organization" width=800px
+ *
  * This class manages multiple rotors and a reflector, allowing for the transformation of input keys.
  * It handles the initialization of rotors, their positions, and the transformation process.
  */

--- a/docs/Architecture.md
+++ b/docs/Architecture.md
@@ -130,3 +130,5 @@ As a result, the rotor movement and resulting cipher output match authentic Enig
 ### 4.2. Signal Path Sequence
 
 ![Encryption Sequence](diagrams/output/Enigma_Encryption_Sequence_Diagram.svg)
+
+For a detailed visual and technical breakdown of the electrical path and component roles, see [Technical Workings of the Enigma Machine](EnigmaMachineWorkings.md).

--- a/docs/EnigmaMachineWorkings.md
+++ b/docs/EnigmaMachineWorkings.md
@@ -1,0 +1,56 @@
+# Technical Workings of the Enigma Machine
+
+This document explains the internal mechanics and signal flow of the Enigma machine simulation, supported by technical diagrams.
+
+## 1. Complete Signal Flow
+
+The Enigma machine operates on a reciprocal electrical signal path. This means that with the same configuration (rotor selection, positions, ring settings, and plugboard pairs), the process of encryption and decryption is identical.
+
+### Signal Path Journey
+1.  **Keyboard Entry:** The operator presses a key.
+2.  **Plugboard (Entry):** The signal passes through the plugboard, where it may be swapped with another letter if a cable is connected.
+3.  **Entry Wheel (ETW):** Maps the keyboard/plugboard signal to the input of the rotor assembly.
+4.  **Rotor Stepping:** Before the signal passes through the rotors, the mechanical stepping mechanism advances the rightmost rotor (and potentially others).
+5.  **Rotor Assembly (Forward):** The signal passes through each rotor from right to left.
+6.  **Reflector (UKW):** The signal is reflected back, essentially swapping the character and sending it on a return path.
+7.  **Rotor Assembly (Reverse):** The signal passes back through the rotors from left to right using their inverse mappings.
+8.  **Plugboard (Exit):** The signal passes through the plugboard a second time (using the same cable connections).
+9.  **Lampboard:** The resulting signal illuminates a lamp on the panel.
+
+![Signal Flow Diagram](diagrams/signal-flow.svg)
+
+---
+
+## 2. RotorBox Organization
+
+The `RotorBox` manages the assembly of rotors and the reflector. In our simulation, Rotor 0 represents the rightmost (fast) rotor, which increments with every key press.
+
+### Components
+*   **Rotors:** Each rotor has internal wiring that performs a substitution cipher. As rotors rotate, the effective substitution mapping shifts.
+*   **Notches:** Physical notches on the rotors trigger the turnover of the adjacent rotor to the left.
+*   **The Reflector:** A static component at the end of the chain that ensures the signal returns through the rotors, providing the machine's reciprocal property.
+
+![RotorBox Organization](diagrams/rotorbox-organization.svg)
+
+---
+
+## 3. Plugboard (Steckerbrett) Structure
+
+The plugboard provides an additional layer of security by allowing the operator to swap pairs of letters before they enter the rotor assembly and after they exit.
+
+*   **Pairs:** If 'A' is plugged to 'Z', then 'A' becomes 'Z' and 'Z' becomes 'A'.
+*   **Identity:** If a letter has no cable connected, it passes through unchanged (Identity mapping).
+*   **Constraints:** Each socket can only accommodate one cable end (no letter can be part of two pairs).
+
+![Plugboard Structure](diagrams/plugboard-structure.svg)
+
+---
+
+## 4. References and Further Reading
+
+The following resources provide in-depth technical details on the mechanical and electrical operation of the historical Enigma machine:
+
+*   **Crypto Museum:** [Enigma Signal Path](https://www.cryptomuseum.com/crypto/enigma/index.htm) - Detailed technical analysis of the machine's wiring and components.
+*   **Tony Sale's Codes and Ciphers:** [The Enigma Military Machine](http://www.codesandciphers.org.uk/enigma/index.htm) - Original technical specifications and diagrams.
+*   **Cipher Machines and Cryptology:** [Enigma Procedure](https://www.ciphermachinesandcryptology.com/en/enigmaproc.htm) - Explanation of the stepping mechanism and double-stepping anomaly.
+*   **Wikipedia:** [Enigma Machine](https://en.wikipedia.org/wiki/Enigma_machine) - Comprehensive overview of the machine's history and variations.

--- a/docs/diagrams/plugboard-structure.puml
+++ b/docs/diagrams/plugboard-structure.puml
@@ -1,0 +1,41 @@
+@startuml PlugBoard_Structure_Diagram
+
+' Header Comment: This diagram illustrates the Plugboard (Steckerbrett) functionality,
+' showing how letter pairs are swapped bidirectionally and how unplugged letters
+' pass through unchanged.
+
+skinparam monochrome true
+skinparam shadowing false
+
+rectangle "PlugBoard" {
+    together {
+        (A)
+        (B)
+        (C)
+        (D)
+        (...)
+        (Z)
+    }
+
+    ' Example swaps
+    (A) <-> (Z) : Cable 1
+    (B) <-> (E) : Cable 2
+
+    ' Pass through
+    (C) -[hidden]> (C) : Unplugged (Identity)
+}
+
+note right
+  **Swap Logic**
+  Input: X -> Y
+  Output: Y -> X
+  (Bidirectional/Reciprocal)
+endnote
+
+legend bottom
+  - Connected letters (e.g., A-Z) are swapped.
+  - Unconnected letters (e.g., C) remain unchanged.
+  - A socket can only have one plug (conflict prevention).
+endlegend
+
+@enduml

--- a/docs/diagrams/rotorbox-organization.puml
+++ b/docs/diagrams/rotorbox-organization.puml
@@ -1,0 +1,45 @@
+@startuml RotorBox_Organization_Diagram
+
+' Header Comment: This diagram illustrates the physical and logical arrangement of the RotorBox components,
+' showing the assembly of rotors, the entry wheel conceptual position, and the reflector.
+
+skinparam monochrome true
+skinparam shadowing false
+skinparam componentStyle uml2
+
+package "RotorBox Assembly" {
+    [Entry Wheel\n(Conceptual)] as ETW
+
+    component "Rotor 0\n(Fast/Rightmost)" as R0
+    component "Rotor 1\n(Middle)" as R1
+    component "Rotor 2\n(Slow/Leftmost)" as R2
+
+    component "Reflector\n(Umkehrwalze)" as REF
+}
+
+note bottom of R0: Steps every key press
+note bottom of R1: Steps if R0 at notch\n(Middle rotor anomaly)
+note bottom of R2: Steps if R1 at notch
+
+' Signal Flow
+ETW -right-> R0 : Forward Pass
+R0 -right-> R1
+R1 -right-> R2
+R2 -right-> REF
+
+REF -left-> R2 : Reverse Pass
+R2 -left-> R1
+R1 -left-> R0
+R0 -left-> ETW
+
+' Stepping logic indication
+R0 .up.> R1 : triggers
+R1 .up.> R2 : triggers
+
+legend right
+  **Signal Path**
+  Forward: ETW -> R0 -> R1 -> R2 -> REF
+  Reverse: REF -> R2 -> R1 -> R0 -> ETW
+endlegend
+
+@enduml

--- a/docs/diagrams/signal-flow.puml
+++ b/docs/diagrams/signal-flow.puml
@@ -1,0 +1,61 @@
+@startuml Enigma_Signal_Flow_Diagram
+
+' Header Comment: This diagram shows the complete electrical path of a signal
+' from the key press to the lamp illumination, illustrating the Enigma's
+' reciprocal property.
+
+skinparam monochrome true
+skinparam shadowing false
+skinparam responseMessageBelowArrow true
+
+actor "Operator (Key Press)" as User
+participant "Keyboard" as KB
+participant "PlugBoard" as PB
+participant "Entry Wheel" as ETW
+participant "RotorBox\n(Rotors + Reflector)" as RB
+participant "Lampboard" as LP
+
+User -> KB : Press Key (e.g., 'A')
+activate KB
+
+    KB -> PB : Send Signal
+    activate PB
+    note over PB : 1. First Swap
+    PB -> ETW : Swapped Signal
+    deactivate PB
+
+    activate ETW
+    ETW -> RB : Entrance to Rotors
+    deactivate ETW
+
+    activate RB
+    note over RB : 2. Mechanical Step\n(Middle rotor anomaly applies)
+    note over RB : 3. Forward Pass\n(Fast -> Middle -> Slow)
+    note over RB : 4. Reflection\n(Mathematical Inverse)
+    note over RB : 5. Reverse Pass\n(Slow -> Middle -> Fast)
+    RB -> ETW : Exit to Entry Wheel
+    deactivate RB
+
+    activate ETW
+    ETW -> PB : Return Signal
+    deactivate ETW
+
+    activate PB
+    note over PB : 6. Second Swap\n(Same wiring)
+    PB -> LP : Final Signal
+    deactivate PB
+
+    activate LP
+    LP --> User : Light Lamp (e.g., 'G')
+    deactivate LP
+
+deactivate KB
+
+legend center
+  **Reciprocal Property**
+  Due to the Reflector and Plugboard symmetry,
+  if 'A' results in 'G', then 'G' results in 'A'
+  with the same machine settings.
+endlegend
+
+@enduml

--- a/roadmap.md
+++ b/roadmap.md
@@ -29,6 +29,9 @@ To provide a high-performance, zero-overhead, and platform-agnostic Enigma ciphe
 - [x] **Historical Assets & Documentation:**
     - Integrated full set of historical Enigma I rotors (I-V) and reflectors (A-C).
     - Documented wiring sources and technical specifications in [docs/Historical_Data.md](docs/Historical_Data.md).
+- [x] **Technical Documentation & Visualization:**
+    - Created PlantUML diagrams for RotorBox assembly, Plugboard structure, and Signal Flow.
+    - Integrated visualizations into the source code documentation (Doxygen).
 
 ## Phase 2: Universal Portability & PAL (Platform Abstraction Layer)
 **Goal:** Decouple from the OS and C++ Runtime (Exceptions/Filesystem).


### PR DESCRIPTION
## Description

This PR addresses Issue #46 

- Create rotorbox-organization.puml to illustrate assembly and stepping
- Create plugboard-structure.puml to visualize bidirectional swapping
- Create signal-flow.puml showing the complete electrical path
- Add docs/EnigmaMachineWorkings.md with technical explanations
- Integrate diagrams into Doxygen headers via @image commands
- Link internal workings documentation in README and Architecture.md
- Update roadmap to reflect completion of technical visualizations

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Tools update

## How Has This Been Validated?

No validation necessary.

**Test Configuration**:
* Compiler/Toolchain:
* OS/Platform:

## Checklist:

- [x] My code is documented with doxygen comments
- [x] I have made corresponding changes to the documentation
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Additional Information

No additional information.

## Contributors

List of contributors to this pull request:
- @alvarocleite 
