### PR TITLE
Run documentation workflow on pull requests

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
       - main
+  pull_request:
+    branches:
+      - main
   workflow_dispatch:
 
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
@@ -57,6 +60,8 @@ jobs:
           path: 'docs/doxygen-gen-files/html'
 
   deploy:
+    # Only deploy on pushes to main or manual triggers on main
+    if: github.event_name != 'pull_request' && github.ref == 'refs/heads/main'
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}


### PR DESCRIPTION
## Description

This PR addresses Issue #24 

- Add pull_request trigger for the main branch to verify documentation integrity (PlantUML, Doxygen) before merging.
- Restrict the 'deploy' job to only run on push events to main or manual workflow dispatch, preventing unauthorized deployments from unmerged pull requests.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes, no api changes)
- [x] Tools update

## How Has This Been Validated?

After PR is open.

**Test Configuration**:
* Compiler/Toolchain:
* OS/Platform: Linux

## Checklist:

- [x] My code is documented with doxygen comments
- [x] I have made corresponding changes to the documentation
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Additional Information

No additional information.

## Contributors

List of contributors to this pull request:
- @alvarocleite 
