### PR TITLE
Pre-commit hooks to run on protected branches - CI

### DIFF
--- a/scripts/check-protected-branch.sh
+++ b/scripts/check-protected-branch.sh
@@ -6,6 +6,12 @@ PROTECTED_BRANCHES=("main" "development")
 # Get current branch name
 CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
 
+# Skip check in CI environments (like GitHub Actions)
+# This allows CI to run pre-commit checks on protected branches themselves
+if [ "$GITHUB_ACTIONS" == "true" ]; then
+    exit 0
+fi
+
 # Check if current branch is in the protected list
 for branch in "${PROTECTED_BRANCHES[@]}"; do
     if [ "$CURRENT_BRANCH" == "$branch" ]; then


### PR DESCRIPTION
## Description

- Add a bypass to the protected branch check if GITHUB_ACTIONS is true.
- This prevents the pre-commit workflow from failing when validating Pull Requests targeting or originating from 'main' or 'development'.
- Maintains local protection for developers while enabling CI coverage.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes, no api changes)
- [x] Tools update

## How Has This Been Validated?

It will be tested by CI run.

**Test Configuration**:
* Compiler/Toolchain:
* OS/Platform: Linux

## Checklist:

- [ ] My code is documented with doxygen comments
- [ ] I have made corresponding changes to the documentation
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Additional Information

No additional information.

## Contributors

List of contributors to this pull request:
- @alvarocleite 
