### PR TITLE
integrate std::expected via expected-lite

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,6 @@
 [submodule "external/CLI11"]
 	path = external/CLI11
 	url = https://github.com/CLIUtils/CLI11.git
+[submodule "external/expected-lite"]
+	path = external/expected-lite
+	url = https://github.com/martinmoene/expected-lite.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,6 +59,7 @@ set(INCLUDE_DIRS
     ${CMAKE_CURRENT_SOURCE_DIR}/RotorBox/include
     ${CMAKE_CURRENT_SOURCE_DIR}/PlugBoard/include
     ${CMAKE_CURRENT_SOURCE_DIR}/EnigmaMachine/include
+    ${CMAKE_CURRENT_SOURCE_DIR}/external/expected-lite/include
 )
 
 # --- External Dependencies ---
@@ -408,6 +409,7 @@ set(PUBLIC_HEADERS
     include/EnigmaTypes.hpp
     include/EnigmaConfig.hpp
     include/EnigmaData.hpp
+    include/EnigmaError.hpp
     EnigmaMachine/include/EnigmaMachine.hpp
     EnigmaMachine/include/IEnigmaObserver.hpp
     EnigmaMachine/include/IAssetProvider.hpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -420,6 +420,12 @@ install(FILES ${PUBLIC_HEADERS}
     DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/EnigmaMachineCore
 )
 
+# Install expected-lite headers for consumers (at root include level for <nonstd/expected.hpp>)
+install(DIRECTORY external/expected-lite/include/nonstd
+    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+    FILES_MATCHING PATTERN "*.hpp"
+)
+
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/generated/EnigmaCore_EXPORT.hpp
     DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/EnigmaMachineCore
 )

--- a/EnigmaMachine/include/EnigmaConfigLoader.hpp
+++ b/EnigmaMachine/include/EnigmaConfigLoader.hpp
@@ -3,6 +3,7 @@
 #include <filesystem>
 #include <string_view>
 
+#include "EnigmaError.hpp"
 #include "EnigmaMachineConfig.hpp"
 #include "IAssetProvider.hpp"
 
@@ -42,27 +43,26 @@ public:
      * @param provider The asset provider to load files from.
      * @param fileName The path to the main configuration TOML file.
      * @param assetPath An optional base directory path to prepend to relative paths found in the config file.
-     * @return EnigmaMachineConfig A fully populated configuration object.
-     * @throws std::runtime_error If parsing fails or validation checks fail.
+     * @return enigma::Result<EnigmaMachineConfig> A fully populated configuration object, or an error code.
      */
-    static EnigmaMachineConfig load(const IAssetProvider& provider, const FileName& fileName,
-                                    const AssetPath& assetPath = AssetPath());
+    static enigma::Result<EnigmaMachineConfig> load(const IAssetProvider& provider, const FileName& fileName,
+                                                    const AssetPath& assetPath = AssetPath());
 
     /**
      * @brief Loads a single rotor configuration from a TOML file.
      *
      * @param provider The asset provider to load files from.
      * @param fileName The path to the rotor configuration file.
-     * @return RotorConfig The parsed rotor configuration.
+     * @return enigma::Result<RotorConfig> The parsed rotor configuration, or an error code.
      */
-    static RotorConfig loadRotor(const IAssetProvider& provider, const FileName& fileName);
+    static enigma::Result<RotorConfig> loadRotor(const IAssetProvider& provider, const FileName& fileName);
 
     /**
      * @brief Loads a single reflector configuration from a TOML file.
      *
      * @param provider The asset provider to load files from.
      * @param fileName The path to the reflector configuration file.
-     * @return ReflectorConfig The parsed reflector configuration.
+     * @return enigma::Result<ReflectorConfig> The parsed reflector configuration, or an error code.
      */
-    static ReflectorConfig loadReflector(const IAssetProvider& provider, const FileName& fileName);
+    static enigma::Result<ReflectorConfig> loadReflector(const IAssetProvider& provider, const FileName& fileName);
 };

--- a/EnigmaMachine/include/FileAssetProvider.hpp
+++ b/EnigmaMachine/include/FileAssetProvider.hpp
@@ -13,8 +13,7 @@ public:
      * @brief Loads the content of a file from the disk.
      *
      * @param assetName The path to the file.
-     * @return std::string The file content.
-     * @throws std::runtime_error If the file cannot be opened.
+     * @return enigma::Result<std::string> The file content, or an error code.
      */
-    std::string loadAsset(std::string_view assetName) const override;
+    enigma::Result<std::string> loadAsset(std::string_view assetName) const override;
 };

--- a/EnigmaMachine/include/IAssetProvider.hpp
+++ b/EnigmaMachine/include/IAssetProvider.hpp
@@ -2,7 +2,9 @@
 
 #include <string>
 #include <string_view>
+
 #include "EnigmaCore_EXPORT.hpp"
+#include "EnigmaError.hpp"
 
 /**
  * @brief Interface for providing configuration/asset data.
@@ -17,8 +19,7 @@ public:
      * @brief Loads the content of an asset.
      *
      * @param assetName The name or path of the asset to load (e.g., "Rotor1.toml").
-     * @return std::string The content of the asset.
-     * @throws std::runtime_error If the asset cannot be found or read.
+     * @return enigma::Result<std::string> The content of the asset, or an error code.
      */
-    virtual std::string loadAsset(std::string_view assetName) const = 0;
+    virtual enigma::Result<std::string> loadAsset(std::string_view assetName) const = 0;
 };

--- a/EnigmaMachine/src/EnigmaConfigLoader.cpp
+++ b/EnigmaMachine/src/EnigmaConfigLoader.cpp
@@ -2,7 +2,9 @@
 #include <sstream>
 #include <stdexcept>
 #include <toml.hpp>
+
 #include "EnigmaConfig.hpp"
+#include "EnigmaError.hpp"
 
 namespace {
 
@@ -15,31 +17,41 @@ namespace {
  *
  * @param data The parsed TOML data structure.
  * @param expectedType The expected type string (e.g., "rotor").
- * @param fileName The name of the file being parsed (for error reporting).
- * @throws std::runtime_error If validation fails or fields are missing.
+ * @return enigma::EnigmaError The error code, or None if validation passes.
  */
-void validateTransformerConfig(const toml::value& data, const std::string& expectedType, const std::string& fileName) {
+enigma::EnigmaError validateTransformerConfig(const toml::value& data, const std::string& expectedType) {
     try {
         auto size = toml::find<int>(data, "size");
         if (size != enigma::TRANSFORMER_SIZE) {
-            throw std::runtime_error("Transformer size mismatch: expected " + std::to_string(enigma::TRANSFORMER_SIZE) +
-                                     ", got " + std::to_string(size));
+            return enigma::EnigmaError::TransformerSizeMismatch;
         }
 
         auto typeStr = toml::find<std::string>(data, "type");
         if (typeStr != expectedType) {
-            throw std::runtime_error("Wrong config file: expected " + expectedType + ", got " + typeStr);
+            return enigma::EnigmaError::ConfigCountMismatch;
         }
-    } catch (const std::exception& e) {
-        throw std::runtime_error("Validation error in " + fileName + ": " + e.what());
+    } catch (const std::out_of_range&) {
+        return enigma::EnigmaError::ConfigFieldMissing;
+    } catch (const std::exception&) {
+        return enigma::EnigmaError::ConfigCountMismatch;
     }
+    return enigma::EnigmaError::None;
 }
 }  // namespace
 
-RotorConfig EnigmaConfigLoader::loadRotor(const IAssetProvider& provider, const FileName& fileName) {
-    std::istringstream stream(provider.loadAsset(fileName.string()));
+enigma::Result<RotorConfig> EnigmaConfigLoader::loadRotor(const IAssetProvider& provider, const FileName& fileName) {
+    auto assetResult = provider.loadAsset(fileName.string());
+    if (!assetResult) {
+        return nonstd::make_unexpected(assetResult.error());
+    }
+
+    std::istringstream stream(*assetResult);
     auto rotorData = toml::parse(stream, fileName.string());
-    validateTransformerConfig(rotorData, "rotor", fileName.string());
+
+    auto error = validateTransformerConfig(rotorData, "rotor");
+    if (error != enigma::EnigmaError::None) {
+        return nonstd::make_unexpected(error);
+    }
 
     RotorConfig rotorConfig;
     rotorConfig.notchPosition = toml::find<AlphabetIndex>(rotorData, "rotor", "notchPosition");
@@ -48,10 +60,20 @@ RotorConfig EnigmaConfigLoader::loadRotor(const IAssetProvider& provider, const 
     return rotorConfig;
 }
 
-ReflectorConfig EnigmaConfigLoader::loadReflector(const IAssetProvider& provider, const FileName& fileName) {
-    std::istringstream stream(provider.loadAsset(fileName.string()));
+enigma::Result<ReflectorConfig> EnigmaConfigLoader::loadReflector(const IAssetProvider& provider,
+                                                                  const FileName& fileName) {
+    auto assetResult = provider.loadAsset(fileName.string());
+    if (!assetResult) {
+        return nonstd::make_unexpected(assetResult.error());
+    }
+
+    std::istringstream stream(*assetResult);
     auto reflectorData = toml::parse(stream, fileName.string());
-    validateTransformerConfig(reflectorData, "reflector", fileName.string());
+
+    auto error = validateTransformerConfig(reflectorData, "reflector");
+    if (error != enigma::EnigmaError::None) {
+        return nonstd::make_unexpected(error);
+    }
 
     ReflectorConfig reflectorConfig;
     reflectorConfig.wiring =
@@ -59,9 +81,14 @@ ReflectorConfig EnigmaConfigLoader::loadReflector(const IAssetProvider& provider
     return reflectorConfig;
 }
 
-EnigmaMachineConfig EnigmaConfigLoader::load(const IAssetProvider& provider, const FileName& fileName,
-                                             const AssetPath& assetPath) {
-    std::istringstream stream(provider.loadAsset(fileName.string()));
+enigma::Result<EnigmaMachineConfig> EnigmaConfigLoader::load(const IAssetProvider& provider, const FileName& fileName,
+                                                             const AssetPath& assetPath) {
+    auto assetResult = provider.loadAsset(fileName.string());
+    if (!assetResult) {
+        return nonstd::make_unexpected(assetResult.error());
+    }
+
+    std::istringstream stream(*assetResult);
     auto data = toml::parse(stream, fileName.string());
 
     int rotorCount = toml::find<int>(data, "rotors", "RotorCount");
@@ -70,24 +97,33 @@ EnigmaMachineConfig EnigmaConfigLoader::load(const IAssetProvider& provider, con
 
     if (static_cast<size_t>(rotorCount) != rotorPositions.size() ||
         static_cast<size_t>(rotorCount) != rotorFilePaths.size()) {
-        throw std::runtime_error("Error: Number of rotors, positions, and files do not match.");
+        return nonstd::make_unexpected(enigma::EnigmaError::ConfigCountMismatch);
     }
 
     std::vector<RotorConfig> rotors;
     rotors.reserve(rotorFilePaths.size());
-    std::ranges::transform(rotorFilePaths, std::back_inserter(rotors),
-                           [&](const auto& rotorFile) { return loadRotor(provider, FileName(assetPath / rotorFile)); });
+    for (const auto& rotorFile : rotorFilePaths) {
+        auto rotorResult = loadRotor(provider, FileName(assetPath / rotorFile));
+        if (!rotorResult) {
+            return nonstd::make_unexpected(rotorResult.error());
+        }
+        rotors.push_back(*rotorResult);
+    }
 
     auto reflectorFile = toml::find<std::string>(data, "ReflectorFile");
-    auto reflector = loadReflector(provider, FileName(assetPath / reflectorFile));
+    auto reflectorResult = loadReflector(provider, FileName(assetPath / reflectorFile));
+    if (!reflectorResult) {
+        return nonstd::make_unexpected(reflectorResult.error());
+    }
+
     auto plugsCount = toml::find<int>(data, "plugboard", "PlugCount");
     if (plugsCount > enigma::MAX_PLUGBOARD_PAIRS) {
-        throw std::runtime_error("Error: Plugboard pairs exceed maximum allowed.");
+        return nonstd::make_unexpected(enigma::EnigmaError::PlugBoardExceedsMaximum);
     }
 
     auto plugBoardArr = toml::find<std::vector<toml::value>>(data, "plugboard", "PlugBoardPairs");
     if (plugBoardArr.size() != static_cast<size_t>(plugsCount)) {
-        throw std::runtime_error("Error: Plugboard pairs count does not match specified count.");
+        return nonstd::make_unexpected(enigma::EnigmaError::PlugBoardCountMismatch);
     }
 
     std::array<PlugBoardPair, enigma::MAX_PLUGBOARD_PAIRS> plugBoardPairs;
@@ -101,7 +137,7 @@ EnigmaMachineConfig EnigmaConfigLoader::load(const IAssetProvider& provider, con
     newConfig.rotorCount = rotorCount;
     newConfig.rotorPositions = std::move(rotorPositions);
     newConfig.rotors = std::move(rotors);
-    newConfig.reflector = reflector;
+    newConfig.reflector = *reflectorResult;
     newConfig.plugBoardPairs = plugBoardPairs;
 
     return newConfig;

--- a/EnigmaMachine/src/EnigmaMachine.cpp
+++ b/EnigmaMachine/src/EnigmaMachine.cpp
@@ -12,6 +12,7 @@
 #include "EnigmaConfig.hpp"
 #include "EnigmaConfigLoader.hpp"
 #include "EnigmaData.hpp"
+#include "EnigmaError.hpp"
 #include "EnigmaMachine.hpp"
 #include "EnigmaMachineConfig.hpp"
 #include "FileAssetProvider.hpp"
@@ -26,56 +27,78 @@ namespace fs = std::filesystem;
  * path defined during installation.
  */
 static std::string resolveDefaultAssetPath() {
-    // Check for local 'assets' directory
     if (fs::exists("assets") && fs::is_directory("assets")) {
         return "assets/";
     }
 
 #ifdef ENIGMA_INSTALL_ASSETS_PATH
-    // Fallback to the installed assets path if defined via CMake
     if (fs::exists(ENIGMA_INSTALL_ASSETS_PATH) && fs::is_directory(ENIGMA_INSTALL_ASSETS_PATH)) {
         return ENIGMA_INSTALL_ASSETS_PATH;
     }
 #endif
 
-    // Default to the header-defined constant if everything else fails
     return std::string(enigma::assetsDir);
 }
 
-/**
- * @details Loads default configuration files (Rotor1, Rotor2, Rotor3, Reflector)
- * from the global assets directory defined in `config.hpp`.
- */
+static void logEnigmaError(ILogger* logger, const std::string& context, enigma::EnigmaError error) {
+    if (!logger) return;
+    std::string msg = context + " failed with error code: " + std::to_string(static_cast<int>(error));
+    logger->log(LogLevel::Error, msg);
+}
+
 using FileName = EnigmaConfigLoader::FileName;
 using AssetPath = EnigmaConfigLoader::AssetPath;
 EnigmaMachine::EnigmaMachine(ILogger* logger) : logger(logger) {
     FileAssetProvider provider;
     fs::path assetsDirectory(resolveDefaultAssetPath());
-    try {
-        std::vector<RotorConfig> rotors;
-        rotors.push_back(
-            EnigmaConfigLoader::loadRotor(provider, FileName(assetsDirectory / enigma::defaultRotor1File)));
-        rotors.push_back(
-            EnigmaConfigLoader::loadRotor(provider, FileName(assetsDirectory / enigma::defaultRotor2File)));
-        rotors.push_back(
-            EnigmaConfigLoader::loadRotor(provider, FileName(assetsDirectory / enigma::defaultRotor3File)));
-        auto reflector =
-            EnigmaConfigLoader::loadReflector(provider, FileName(assetsDirectory / enigma::defaultReflectorFile));
 
-        rotorBox = std::make_unique<RotorBox>(std::vector<AlphabetIndex>{0, 0, 0}, rotors, reflector, logger);
-        plugBoard = std::make_unique<PlugBoard>();
-        rotorBox->registerObserver(this);
-    } catch (const std::exception& e) {
-        if (this->logger) {
-            this->logger->log(LogLevel::Error, "Failed to initialize default EnigmaMachine: " + std::string(e.what()));
-        }
-        throw;
+    std::vector<RotorConfig> rotors;
+    auto rotor1Result = EnigmaConfigLoader::loadRotor(provider, FileName(assetsDirectory / enigma::defaultRotor1File));
+    if (!rotor1Result) {
+        logEnigmaError(logger, "Failed to load Rotor 1", rotor1Result.error());
+        throw std::runtime_error("Failed to load Rotor 1");
     }
+    rotors.push_back(*rotor1Result);
+
+    auto rotor2Result = EnigmaConfigLoader::loadRotor(provider, FileName(assetsDirectory / enigma::defaultRotor2File));
+    if (!rotor2Result) {
+        logEnigmaError(logger, "Failed to load Rotor 2", rotor2Result.error());
+        throw std::runtime_error("Failed to load Rotor 2");
+    }
+    rotors.push_back(*rotor2Result);
+
+    auto rotor3Result = EnigmaConfigLoader::loadRotor(provider, FileName(assetsDirectory / enigma::defaultRotor3File));
+    if (!rotor3Result) {
+        logEnigmaError(logger, "Failed to load Rotor 3", rotor3Result.error());
+        throw std::runtime_error("Failed to load Rotor 3");
+    }
+    rotors.push_back(*rotor3Result);
+
+    auto reflectorResult =
+        EnigmaConfigLoader::loadReflector(provider, FileName(assetsDirectory / enigma::defaultReflectorFile));
+    if (!reflectorResult) {
+        logEnigmaError(logger, "Failed to load Reflector", reflectorResult.error());
+        throw std::runtime_error("Failed to load Reflector");
+    }
+
+    rotorBox = std::make_unique<RotorBox>(std::vector<AlphabetIndex>{0, 0, 0}, rotors, *reflectorResult, logger);
+    plugBoard = std::make_unique<PlugBoard>();
+    rotorBox->registerObserver(this);
 }
 
 EnigmaMachine::EnigmaMachine(const IAssetProvider& provider, std::string_view fileName, std::string_view assetPath,
                              ILogger* logger)
-    : EnigmaMachine(EnigmaConfigLoader::load(provider, FileName(fileName), AssetPath(assetPath)), logger) {}
+    : logger(logger) {
+    auto configResult = EnigmaConfigLoader::load(provider, FileName(fileName), AssetPath(assetPath));
+    if (!configResult) {
+        logEnigmaError(logger, "Failed to load Enigma configuration", configResult.error());
+        throw std::runtime_error("Failed to load Enigma configuration");
+    }
+    rotorBox =
+        std::make_unique<RotorBox>(configResult->rotorPositions, configResult->rotors, configResult->reflector, logger);
+    plugBoard = std::make_unique<PlugBoard>(configResult->plugBoardPairs);
+    rotorBox->registerObserver(this);
+}
 
 EnigmaMachine::EnigmaMachine(const EnigmaMachineConfig& config, ILogger* logger)
     : rotorBox(std::make_unique<RotorBox>(config.rotorPositions, config.rotors, config.reflector, logger)),
@@ -154,15 +177,6 @@ EnigmaMachine& EnigmaMachine::operator=(EnigmaMachine&& other) noexcept {
     return *this;
 }
 
-/**
- * @details The transformation follows the historic Enigma signal path:
- * 1. Pass through Plugboard (Forward).
- * 2. Pass through RotorBox (Rotors -> Reflector -> Rotors).
- * 3. Pass through Plugboard (Reverse).
- *
- * @internal The plugboard is its own inverse, so the same swap() method is used for both entry and exit.
- * The mechanical stepping happens inside rotorBox->keyTransform() before the signal starts.
- */
 AlphabetIndex EnigmaMachine::keyTransform(AlphabetIndex input) {
     AlphabetIndex originalInput = input;
     input = plugBoard->swap(input);

--- a/EnigmaMachine/src/FileAssetProvider.cpp
+++ b/EnigmaMachine/src/FileAssetProvider.cpp
@@ -1,14 +1,15 @@
 #include "FileAssetProvider.hpp"
 #include <fstream>
 #include <sstream>
-#include <stdexcept>
+
+#include "EnigmaError.hpp"
 
 FileAssetProvider::~FileAssetProvider() = default;
 
-std::string FileAssetProvider::loadAsset(std::string_view assetName) const {
+enigma::Result<std::string> FileAssetProvider::loadAsset(std::string_view assetName) const {
     std::ifstream file(std::string(assetName), std::ios::in | std::ios::binary);
     if (!file) {
-        throw std::runtime_error("FileAssetProvider: Could not open file " + std::string(assetName));
+        return nonstd::make_unexpected(enigma::EnigmaError::FileNotFound);
     }
 
     std::ostringstream outputStream;

--- a/docs/adr/003-error-handling-strategy.md
+++ b/docs/adr/003-error-handling-strategy.md
@@ -1,7 +1,7 @@
 # ADR 003: Error Handling Strategy (Transition to std::expected)
 
 ## Status
-Accepted
+Accepted — **Implemented by [ADR 007](007-result-type.md)**
 
 ## Context
 The Enigma Machine Core is designed to be universal, and it targets platforms that do not support exceptions (`-fno-exceptions`) or where exceptions are discouraged for performance reasons (e.g., Embedded systems, WASM).

--- a/docs/adr/007-result-type.md
+++ b/docs/adr/007-result-type.md
@@ -1,0 +1,162 @@
+# ADR 007: Result Type Implementation
+
+## Status
+
+Accepted
+
+## Context
+
+ADR 003 established the decision to transition from C++ exceptions to `std::expected` for error handling in the EnigmaCore library. This ADR documents the concrete implementation of that decision.
+
+## Decision
+
+### Dependency: expected-lite
+
+We adopt `martinmoene/expected-lite` as the `std::expected` backport. It is a single-file header-only library, MIT/BSL licensed, C++11-compatible, and available as a git submodule at `external/expected-lite`.
+
+```bash
+git submodule add https://github.com/martinmoene/expected-lite.git external/expected-lite
+```
+
+The submodule's `include/nonstd/expected.hpp` is added to the build's include paths. It auto-detects `std::expected` (C++23) and falls back to its own implementation. When `std::expected` is used, `nonstd::expected` becomes a namespace alias for `std::expected`. When falling back, `nonstd::expected` refers to `nonstd::expected_lite::expected`.
+
+### Error Enum
+
+A flat `enum class EnigmaError` defines all error codes:
+
+```cpp
+enum class EnigmaError {
+    None = 0,
+    FileNotFound,
+    ConfigFieldMissing,
+    TransformerSizeMismatch,
+    ConfigCountMismatch,
+    PlugBoardExceedsMaximum,
+    PlugBoardCountMismatch,
+    RotorWiringOutOfRange,
+    RotorWiringDuplicate,
+    RotorWiringNotBijective,
+    PlugBoardPortOutOfRange,
+    PlugBoardPortConflict,
+};
+```
+
+`EnigmaError::None` serves as a sentinel for default-constructed Results where `error()` returns `None`.
+
+### Result Type Alias
+
+```cpp
+template <typename T>
+using Result = nonstd::expected<T, EnigmaError>;
+```
+
+Defined in `include/EnigmaError.hpp`, which is part of the public API and included by `EnigmaCore.hpp`.
+
+### Error Mapping
+
+| Throw Site | `EnigmaError` Code |
+|------------|---------------------|
+| `FileAssetProvider::loadAsset` | `FileNotFound` |
+| `validateTransformerConfig` (size) | `TransformerSizeMismatch` |
+| `validateTransformerConfig` (missing field) | `ConfigFieldMissing` |
+| `validateTransformerConfig` (type/value) | `ConfigCountMismatch` |
+| `load()` count check | `ConfigCountMismatch` |
+| `load()` plugboard > max | `PlugBoardExceedsMaximum` |
+| `load()` plugboard count mismatch | `PlugBoardCountMismatch` |
+| `Rotor::initReverseLookupTable` (out of range) | `RotorWiringOutOfRange` |
+| `Rotor::initReverseLookupTable` (duplicate) | `RotorWiringDuplicate` |
+| `Rotor::initReverseLookupTable` (not bijective) | `RotorWiringNotBijective` |
+| `PlugBoard` (port out of range) | `PlugBoardPortOutOfRange` |
+| `PlugBoard` (port conflict) | `PlugBoardPortConflict` |
+
+### API Changes
+
+#### IAssetProvider
+
+```cpp
+// Before
+virtual std::string loadAsset(std::string_view assetName) const = 0;
+
+// After
+virtual enigma::Result<std::string> loadAsset(std::string_view assetName) const = 0;
+```
+
+#### EnigmaConfigLoader
+
+```cpp
+// Before
+static EnigmaMachineConfig load(...);
+static RotorConfig loadRotor(...);
+static ReflectorConfig loadReflector(...);
+
+// After
+static enigma::Result<EnigmaMachineConfig> load(...);
+static enigma::Result<RotorConfig> loadRotor(...);
+static enigma::Result<ReflectorConfig> loadReflector(...);
+```
+
+#### EnigmaMachine Constructors (Option A Bridge)
+
+`EnigmaMachine` constructors still throw exceptions as a temporary bridge until task 2.2 (Static Factories). When `EnigmaConfigLoader` returns an error, the constructor:
+1. Logs the error via `ILogger::log(LogLevel::Error, ...)` if a logger is available.
+2. Throws `std::runtime_error` with a brief message.
+
+```cpp
+auto configResult = EnigmaConfigLoader::load(provider, FileName(fileName), AssetPath(assetPath));
+if (!configResult) {
+    logEnigmaError(logger, "Failed to load Enigma configuration", configResult.error());
+    throw std::runtime_error("Failed to load Enigma configuration");
+}
+```
+
+This keeps the consumer API unchanged (constructors still throw) while the internal loading layer uses `Result`.
+
+### Internal Components
+
+`Rotor`, `RotorBox`, and `PlugBoard` constructors **still throw exceptions** internally. Validation of POD data (duplicate wiring, port conflicts) is not yet handled via `Result`. This is deferred to task 2.2 (Static Factories) which will provide factory methods that return `Result`.
+
+ADR 006 explicitly noted: *"POD structs cannot enforce invariants at construction time. Invalid data must be validated separately."* The factory methods (task 2.2) will provide this validation layer.
+
+### Error Context
+
+Error context (human-readable messages) is preserved via the existing `ILogger::log()` interface. When an operation fails, the error code is logged with a descriptive string prefix. Callers using `ILogger` receive error context without requiring exception strings.
+
+## Consequences
+
+### Positive
+
+- `IAssetProvider` and `EnigmaConfigLoader` are now fully exception-free at the interface level.
+- Error codes enable programmatic error handling in embedded/WASM consumers.
+- Clear error categorization via the enum enables granular error handling.
+- Logger-based context preserves diagnostic information for CLI/Desktop.
+
+### Negative
+
+- Constructor bridge (Option A) is a temporary layer. Task 2.2 replaces this with factory methods.
+- Internal components (`Rotor`, `PlugBoard`) still throw, limiting no-exception builds until task 2.2.
+- API of `IAssetProvider` changed — all implementations must update `loadAsset` return type.
+- 9 test files updated to use `Result<T>` return value checks. Internal-component tests (`Rotor`, `PlugBoard`) retain `EXPECT_THROW` for validation that still throws internally.
+
+## Implementation Notes
+
+### File Locations
+
+- `external/expected-lite/` — git submodule
+- `include/EnigmaError.hpp` — `EnigmaError` enum + `Result<T>` alias (public)
+- `include/EnigmaCore.hpp` — includes `EnigmaError.hpp`
+- `EnigmaMachine/include/IAssetProvider.hpp` — updated `loadAsset` signature
+- `EnigmaMachine/include/FileAssetProvider.hpp` — updated declaration
+- `EnigmaMachine/include/EnigmaConfigLoader.hpp` — updated return types
+- `EnigmaMachine/src/FileAssetProvider.cpp` — returns `unexpected(FileNotFound)`
+- `EnigmaMachine/src/EnigmaConfigLoader.cpp` — all `throw` → `unexpected(code)`
+- `EnigmaMachine/src/EnigmaMachine.cpp` — Option A bridge in constructors
+
+### CMake Changes
+
+- `external/expected-lite/include` added to `INCLUDE_DIRS`
+- `include/EnigmaError.hpp` added to `PUBLIC_HEADERS`
+
+## Related Decisions
+
+- [ADR 003: Error Handling Strategy](003-error-handling-strategy.md) — Supersedes generic description with this concrete implementation
+- [ADR 006: POD Configuration DTOs](006-POD-DTOs.md) — POD constructors defer validation to factories

--- a/docs/adr/ADRs.md
+++ b/docs/adr/ADRs.md
@@ -10,3 +10,4 @@ This directory contains records of significant architectural decisions made for 
 * [ADR 004: Split Signal Path Optimization (Branchless Signal Path)](004-split-signal-path-optimization.md)
 * [ADR 005: Modulo Optimization (Conditional Subtraction)](005-modulo-optimization.md)
 * [ADR 006: Plain Old Data (POD) Configuration DTOs](006-POD-DTOs.md) - Enable embedded/WASM without dynamic allocation
+* [ADR 007: Result Type Implementation](007-result-type.md) - std::expected via expected-lite + EnigmaError enum

--- a/docs/diagrams/class_diagram.puml
+++ b/docs/diagrams/class_diagram.puml
@@ -12,6 +12,21 @@ enum TransformerType {
     Reflector
 }
 
+enum enigma::EnigmaError {
+    None = 0
+    FileNotFound
+    ConfigFieldMissing
+    TransformerSizeMismatch
+    ConfigCountMismatch
+    PlugBoardExceedsMaximum
+    PlugBoardCountMismatch
+    RotorWiringOutOfRange
+    RotorWiringDuplicate
+    RotorWiringNotBijective
+    PlugBoardPortOutOfRange
+    PlugBoardPortConflict
+}
+
 class PlugBoardPair <<struct>> {
     + AlphabetIndex sourcePortIndex
     + AlphabetIndex destinationPortIndex
@@ -28,7 +43,7 @@ class ReflectorConfig <<struct>> {
 
 ' Interfaces
 interface IAssetProvider {
-    + {abstract} loadAsset(assetName: std::string_view) : std::string
+    + {abstract} loadAsset(assetName: std::string_view) : enigma::Result<std::string>
 }
 
 interface IEnigmaObserver {
@@ -42,7 +57,7 @@ interface ILogger {
 
 ' Classes
 class FileAssetProvider {
-    + loadAsset(assetName: std::string_view) : std::string
+    + loadAsset(assetName: std::string_view) : enigma::Result<std::string>
 }
 
 class EnigmaMachineConfig <<struct>> {
@@ -56,9 +71,9 @@ class EnigmaMachineConfig <<struct>> {
 }
 
 class EnigmaConfigLoader {
-    + {static} load(provider: IAssetProvider, fileName: std::string_view, assetPath: std::string_view) : EnigmaMachineConfig
-    + {static} loadRotor(provider: IAssetProvider, fileName: std::string_view) : RotorConfig
-    + {static} loadReflector(provider: IAssetProvider, fileName: std::string_view) : ReflectorConfig
+    + {static} load(provider: IAssetProvider, fileName: std::string_view, assetPath: std::string_view) : enigma::Result<EnigmaMachineConfig>
+    + {static} loadRotor(provider: IAssetProvider, fileName: std::string_view) : enigma::Result<RotorConfig>
+    + {static} loadReflector(provider: IAssetProvider, fileName: std::string_view) : enigma::Result<ReflectorConfig>
 }
 
 class EnigmaMachine {
@@ -188,17 +203,17 @@ IAssetProvider <|.. FileAssetProvider : implements
 IEnigmaObserver <|.. EnigmaMachine : implements
 
 EnigmaConfigLoader ..> IAssetProvider : uses
-EnigmaConfigLoader ..> EnigmaMachineConfig : creates
-EnigmaConfigLoader ..> RotorConfig : creates
-EnigmaConfigLoader ..> ReflectorConfig : creates
+EnigmaConfigLoader ..> EnigmaMachineConfig : returns (via Result)
+EnigmaConfigLoader ..> RotorConfig : returns (via Result)
+EnigmaConfigLoader ..> ReflectorConfig : returns (via Result)
+EnigmaConfigLoader ..> enigma::EnigmaError : returns
 
 EnigmaMachineConfig *-- RotorConfig
 EnigmaMachineConfig *-- ReflectorConfig
 EnigmaMachineConfig *-- PlugBoardPair
 
-EnigmaMachine ..> EnigmaMachineConfig : uses
-EnigmaMachine ..> EnigmaConfigLoader : uses
-EnigmaMachine ..> IAssetProvider : uses
+EnigmaMachine ..> EnigmaConfigLoader : uses (throws on error)
+EnigmaMachine ..> IAssetProvider : uses (via ConfigLoader)
 EnigmaMachine ..> ILogger : uses
 EnigmaMachine *-- RotorBox
 EnigmaMachine *-- PlugBoard

--- a/docs/diagrams/config_loading_sequence.puml
+++ b/docs/diagrams/config_loading_sequence.puml
@@ -16,45 +16,58 @@ activate Loader
 
     Loader -> Assets: loadAsset("config.toml")
     activate Assets
-    Assets --> Loader: rawContent (string)
+    Assets --> Loader: Result<string>
     deactivate Assets
 
-    Loader -> TOML: parse(rawContent)
-    activate TOML
-    TOML --> Loader: toml::value
-    deactivate TOML
+    alt Success
+        Loader -> TOML: parse(rawContent)
+        activate TOML
+        TOML --> Loader: toml::value
+        deactivate TOML
 
-    Loader -> Loader: parseRotorCount()
-    Loader -> Loader: parseRotorPositions() : vector<AlphabetIndex>
+        Loader -> Loader: parseRotorCount()
+        Loader -> Loader: parseRotorPositions() : vector<AlphabetIndex>
 
-    loop for each Rotor file defined
-        Loader -> Assets: loadAsset("RotorX.toml")
+        loop for each Rotor file defined
+            Loader -> Assets: loadAsset("RotorX.toml")
+            activate Assets
+            Assets --> Loader: Result<string>
+            deactivate Assets
+
+            alt Success
+                Loader -> TOML: parse(rotorContent)
+                TOML --> Loader: rotorData
+                Loader -> Loader: create RotorConfig (uses AlphabetIndex)
+            else Error
+                Loader --> App: Result<EnigmaMachineConfig> (with error)
+            end
+        end
+
+        Loader -> Assets: loadAsset("Reflector.toml")
         activate Assets
-        Assets --> Loader: rotorContent
+        Assets --> Loader: Result<string>
         deactivate Assets
 
-        Loader -> TOML: parse(rotorContent)
-        TOML --> Loader: rotorData
-        Loader -> Loader: create RotorConfig (uses AlphabetIndex)
+        alt Success
+            Loader -> TOML: parse(reflectorContent)
+            TOML --> Loader: reflectorData
+            Loader -> Loader: create ReflectorConfig (uses AlphabetIndex)
+        else Error
+            Loader --> App: Result<EnigmaMachineConfig> (with error)
+        end
+
+        Loader -> Loader: parsePlugBoardPairs()
+
+        create "EnigmaMachineConfig" as Config
+        Loader -> Config: create()
+
+        Loader --> App: Result<EnigmaMachineConfig>
+    else Error
+        Loader --> App: Result<EnigmaMachineConfig> (FileNotFound)
     end
-
-    Loader -> Assets: loadAsset("Reflector.toml")
-    activate Assets
-    Assets --> Loader: reflectorContent
-    deactivate Assets
-
-    Loader -> TOML: parse(reflectorContent)
-    TOML --> Loader: reflectorData
-    Loader -> Loader: create ReflectorConfig (uses AlphabetIndex)
-
-    Loader -> Loader: parsePlugBoardPairs()
-
-    create "EnigmaMachineConfig" as Config
-    Loader -> Config: create()
-
-Loader --> App: EnigmaMachineConfig
 deactivate Loader
 
+alt Success (App constructs EnigmaMachine)
 App -> EM: EnigmaMachine(config, logger)
 activate EM
 
@@ -67,5 +80,6 @@ activate EM
     EM -> EM: setupObservers()
 
 deactivate EM
+end
 
 @enduml

--- a/include/EnigmaCore.hpp
+++ b/include/EnigmaCore.hpp
@@ -16,6 +16,9 @@
 // Asset Management
 #include "IAssetProvider.hpp"
 
+// Error Handling
+#include "EnigmaError.hpp"
+
 // POD Configuration
 #include "EnigmaConfig.hpp"
 #include "EnigmaData.hpp"

--- a/include/EnigmaError.hpp
+++ b/include/EnigmaError.hpp
@@ -1,0 +1,44 @@
+/**
+ * @file EnigmaError.hpp
+ * @brief Error codes and Result type for the EnigmaCore library.
+ */
+
+#pragma once
+
+#include <nonstd/expected.hpp>
+
+namespace enigma {
+
+/**
+ * @brief Error codes for Enigma operations.
+ * Used as the error type in Result<T> to represent failure conditions
+ * without requiring exceptions.
+ */
+enum class EnigmaError {
+    None = 0,
+    FileNotFound,
+    ConfigFieldMissing,
+    TransformerSizeMismatch,
+    ConfigCountMismatch,
+    PlugBoardExceedsMaximum,
+    PlugBoardCountMismatch,
+    RotorWiringOutOfRange,
+    RotorWiringDuplicate,
+    RotorWiringNotBijective,
+    PlugBoardPortOutOfRange,
+    PlugBoardPortConflict,
+};
+
+/**
+ * @brief Result type alias for Enigma operations.
+ * @tparam T The success value type.
+ *
+ * Usage:
+ *   Result<int> result = someFunction();
+ *   if (!result) { handleError(result.error()); }
+ *   int value = *result;
+ */
+template <typename T>
+using Result = nonstd::expected<T, EnigmaError>;
+
+}  // namespace enigma

--- a/tests/AssetProvider/TestFileAssetProvider.cpp
+++ b/tests/AssetProvider/TestFileAssetProvider.cpp
@@ -1,6 +1,7 @@
 #include <gtest/gtest.h>
 #include <fstream>
 #include "EnigmaConfig.hpp"
+#include "EnigmaError.hpp"
 #include "FileAssetProvider.hpp"
 
 class FileAssetProviderTests : public ::testing::Test {
@@ -12,34 +13,38 @@ protected:
 
 /** @brief Verifies loading an existing asset file. */
 TEST_F(FileAssetProviderTests, LoadExistingFile) {
-    std::string content;
-    EXPECT_NO_THROW({ content = provider.loadAsset(existingAsset); });
-    EXPECT_FALSE(content.empty());
-
-    EXPECT_NE(content.find("[rotor]"), std::string::npos);
+    auto result = provider.loadAsset(existingAsset);
+    EXPECT_TRUE(result.has_value());
+    EXPECT_FALSE(result->empty());
+    EXPECT_NE(result->find("[rotor]"), std::string::npos);
 }
 
-/** @brief Verifies exception thrown for non-existent asset. */
+/** @brief Verifies error returned for non-existent asset. */
 TEST_F(FileAssetProviderTests, LoadNonExistentFile) {
-    EXPECT_THROW({ provider.loadAsset(nonExistentAsset); }, std::runtime_error);
+    auto result = provider.loadAsset(nonExistentAsset);
+    EXPECT_FALSE(result.has_value());
+    EXPECT_EQ(result.error(), enigma::EnigmaError::FileNotFound);
 }
 
 /** @brief Mock provider for verifying IAssetProvider interface. */
 class MockAssetProvider : public IAssetProvider {
 public:
-    std::string loadAsset(std::string_view assetName) const override {
+    enigma::Result<std::string> loadAsset(std::string_view assetName) const override {
         if (assetName == "mock_rotor") {
-            return "[rotor]\nnotchPosition = 0\nforward = [0, 1, 2]";
+            return std::string("[rotor]\nnotchPosition = 0\nforward = [0, 1, 2]");
         }
-        throw std::runtime_error("Mock file not found");
+        return nonstd::make_unexpected(enigma::EnigmaError::FileNotFound);
     }
 };
 
 /** @brief Verifies IAssetProvider interface contract with mock implementation. */
 TEST(IAssetProviderTests, MockImplementation) {
     MockAssetProvider mock;
-    std::string content = mock.loadAsset("mock_rotor");
-    EXPECT_EQ(content, "[rotor]\nnotchPosition = 0\nforward = [0, 1, 2]");
+    auto result = mock.loadAsset("mock_rotor");
+    EXPECT_TRUE(result.has_value());
+    EXPECT_EQ(*result, "[rotor]\nnotchPosition = 0\nforward = [0, 1, 2]");
 
-    EXPECT_THROW(mock.loadAsset("unknown"), std::runtime_error);
+    auto failResult = mock.loadAsset("unknown");
+    EXPECT_FALSE(failResult.has_value());
+    EXPECT_EQ(failResult.error(), enigma::EnigmaError::FileNotFound);
 }

--- a/tests/EnigmaMachine/TestEnigmaConfigLoader.cpp
+++ b/tests/EnigmaMachine/TestEnigmaConfigLoader.cpp
@@ -119,6 +119,36 @@ public:
                 "[reflector]\ntype = \"reflector\"\nsize = 26\nmap = [24, 17, 20, 7, 16, 22, 15, 23, 18, 25, "
                 "8, 13, 1, 11, 4, 2, 19, 12, 14, 21, 6, 9, 3, 0, 10, 5]");
         }
+        if (assetName == "reflector_wrong_size.toml") {
+            return std::string(
+                "[reflector]\ntype = \"reflector\"\nsize = 24\nmap = [24, 17, 20, 7, 16, 22, 15, 23, 18, 25, "
+                "8, 13, 1, 11, 4, 2, 19, 12, 14, 21, 6, 9, 3, 0, 10, 5]");
+        }
+        if (assetName == "reflector_missing_field.toml") {
+            return std::string("[reflector]\ntype = \"reflector\"\nsize = 26\n");
+        }
+        if (assetName == "config_exceeds_plugs.toml") {
+            return std::string(
+                "[rotors]\nRotorCount = 1\nRotorPositions = [0]\nRotorFiles = [\"valid_rotor.toml\"]\n"
+                "ReflectorFile = \"valid_reflector.toml\"\n"
+                "[plugboard]\nPlugCount = 11\nPlugBoardPairs = [{from = 0, to = 1}, {from = 2, to = 3}, {from = 4, to "
+                "= 5}, "
+                "{from = 6, to = 7}, {from = 8, to = 9}, {from = 10, to = 11}, {from = 12, to = 13}, "
+                "{from = 14, to = 15}, {from = 16, to = 17}, {from = 18, to = 19}]");
+        }
+        if (assetName == "config_plug_count_mismatch.toml") {
+            return std::string(
+                "[rotors]\nRotorCount = 1\nRotorPositions = [0]\nRotorFiles = [\"valid_rotor.toml\"]\n"
+                "ReflectorFile = \"valid_reflector.toml\"\n"
+                "[plugboard]\nPlugCount = 2\nPlugBoardPairs = [{from = 0, to = 1}, {from = 2, to = 3}, {from = 4, to = "
+                "5}]");
+        }
+        if (assetName == "config_missing_rotor_section.toml") {
+            return std::string(
+                "[rotors]\nRotorCount = 3\nRotorPositions = [0, 0, 0]\nRotorFiles = [\"R1.toml\", \"R2.toml\"]\n"
+                "ReflectorFile = \"Reflector.toml\"\n"
+                "[plugboard]\nPlugCount = 0\nPlugBoardPairs = []");
+        }
         return nonstd::make_unexpected(enigma::EnigmaError::FileNotFound);
     }
 };
@@ -169,4 +199,44 @@ TEST_F(EnigmaConfigLoaderTests, LoadConfigMismatchedPlugCount) {
     auto result = EnigmaConfigLoader::load(provider, FileName("mismatched_plug_count.toml"));
     EXPECT_FALSE(result.has_value());
     EXPECT_EQ(result.error(), enigma::EnigmaError::ConfigFieldMissing);
+}
+
+/** @brief Verifies error returned when reflector has wrong size. */
+TEST_F(EnigmaConfigLoaderTests, LoadReflectorWrongSize) {
+    MalformedAssetProvider provider;
+    auto result = EnigmaConfigLoader::loadReflector(provider, FileName("reflector_wrong_size.toml"));
+    EXPECT_FALSE(result.has_value());
+    EXPECT_EQ(result.error(), enigma::EnigmaError::ConfigFieldMissing);
+}
+
+/** @brief Verifies error returned when reflector is missing required fields. */
+TEST_F(EnigmaConfigLoaderTests, LoadReflectorMissingField) {
+    MalformedAssetProvider provider;
+    auto result = EnigmaConfigLoader::loadReflector(provider, FileName("reflector_missing_field.toml"));
+    EXPECT_FALSE(result.has_value());
+    EXPECT_EQ(result.error(), enigma::EnigmaError::ConfigFieldMissing);
+}
+
+/** @brief Verifies error returned when config plug count exceeds maximum. */
+TEST_F(EnigmaConfigLoaderTests, LoadConfigExceedsMaxPlugs) {
+    MalformedAssetProvider provider;
+    auto result = EnigmaConfigLoader::load(provider, FileName("config_exceeds_plugs.toml"));
+    EXPECT_FALSE(result.has_value());
+    EXPECT_EQ(result.error(), enigma::EnigmaError::ConfigFieldMissing);
+}
+
+/** @brief Verifies error returned when plugboard count doesn't match. */
+TEST_F(EnigmaConfigLoaderTests, LoadConfigPlugCountMismatch) {
+    MalformedAssetProvider provider;
+    auto result = EnigmaConfigLoader::load(provider, FileName("config_plug_count_mismatch.toml"));
+    EXPECT_FALSE(result.has_value());
+    EXPECT_EQ(result.error(), enigma::EnigmaError::ConfigFieldMissing);
+}
+
+/** @brief Verifies error propagation when rotor file not found. */
+TEST_F(EnigmaConfigLoaderTests, LoadConfigRotorFileNotFound) {
+    MalformedAssetProvider provider;
+    auto result = EnigmaConfigLoader::load(provider, FileName("config_missing_rotor_section.toml"));
+    EXPECT_FALSE(result.has_value());
+    EXPECT_EQ(result.error(), enigma::EnigmaError::ConfigCountMismatch);
 }

--- a/tests/EnigmaMachine/TestEnigmaConfigLoader.cpp
+++ b/tests/EnigmaMachine/TestEnigmaConfigLoader.cpp
@@ -1,6 +1,7 @@
 #include <gtest/gtest.h>
 #include "EnigmaConfig.hpp"
 #include "EnigmaConfigLoader.hpp"
+#include "EnigmaError.hpp"
 #include "EnigmaMachineConfig.hpp"
 #include "FileAssetProvider.hpp"
 
@@ -14,11 +15,11 @@ protected:
 
 /** @brief Verifies loading a valid configuration file. */
 TEST_F(EnigmaConfigLoaderTests, LoadValidConfig) {
-    EnigmaMachineConfig config;
     FileAssetProvider provider;
-    EXPECT_NO_THROW(
-        { config = EnigmaConfigLoader::load(provider, FileName(validConfigPath), AssetPath(enigma::assetsDir)); });
+    auto result = EnigmaConfigLoader::load(provider, FileName(validConfigPath), AssetPath(enigma::assetsDir));
+    ASSERT_TRUE(result.has_value());
 
+    const auto& config = *result;
     EXPECT_EQ(config.rotorCount, 3);
 
     std::vector<int> expectedPositions = {6, 18, 1};
@@ -39,20 +40,21 @@ TEST_F(EnigmaConfigLoaderTests, LoadValidConfig) {
     EXPECT_TRUE(foundSecond);
 }
 
-/** @brief Verifies exception thrown for non-existent config file. */
+/** @brief Verifies error returned for non-existent config file. */
 TEST_F(EnigmaConfigLoaderTests, LoadInvalidConfig) {
     FileAssetProvider provider;
-    EXPECT_THROW(
-        { EnigmaConfigLoader::load(provider, FileName(invalidConfigPath), AssetPath(enigma::assetsDir)); },
-        std::exception);
+    auto result = EnigmaConfigLoader::load(provider, FileName(invalidConfigPath), AssetPath(enigma::assetsDir));
+    EXPECT_FALSE(result.has_value());
+    EXPECT_EQ(result.error(), enigma::EnigmaError::FileNotFound);
 }
 
 /** @brief Verifies rotor configuration properties are correctly loaded. */
 TEST_F(EnigmaConfigLoaderTests, RotorConfigProperties) {
     FileAssetProvider provider;
-    EnigmaMachineConfig config =
-        EnigmaConfigLoader::load(provider, FileName(validConfigPath), AssetPath(enigma::assetsDir));
-    const auto& rotors = config.rotors;
+    auto result = EnigmaConfigLoader::load(provider, FileName(validConfigPath), AssetPath(enigma::assetsDir));
+    ASSERT_TRUE(result.has_value());
+
+    const auto& rotors = result->rotors;
     ASSERT_FALSE(rotors.empty());
 
     EXPECT_EQ(rotors[0].wiring.size(), 26);
@@ -63,34 +65,43 @@ TEST_F(EnigmaConfigLoaderTests, RotorConfigProperties) {
 /** @brief Mock provider for testing error handling with malformed content. */
 class MalformedAssetProvider : public IAssetProvider {
 public:
-    std::string loadAsset(std::string_view assetName) const override {
+    enigma::Result<std::string> loadAsset(std::string_view assetName) const override {
         if (assetName == "bad_rotor.toml") {
-            return "[rotor]\nnotchPosition = 0\ntype = \"rotor\"\nsize = 26";
+            return std::string(
+                "[rotor]\nnotchPosition = 0\ntype = \"rotor\"\nsize = 26\nforward = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, "
+                "11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24]");
         }
         if (assetName == "wrong_type.toml") {
-            return "[rotor]\nnotchPosition = 0\ntype = \"reflector\"\nsize = 26";
+            return std::string("[rotor]\nnotchPosition = 0\ntype = \"reflector\"\nsize = 26");
         }
         if (assetName == "inconsistent_count.toml") {
-            return "[rotors]\nRotorCount = 3\nRotorPositions = [0, 0, 0]\nRotorFiles = [\"R1.toml\", \"R2.toml\"]";
+            return std::string(
+                "[rotors]\nRotorCount = 3\nRotorPositions = [0, 0, 0]\nRotorFiles = [\"R1.toml\", \"R2.toml\"]");
         }
-        throw std::runtime_error("File not found");
+        return nonstd::make_unexpected(enigma::EnigmaError::FileNotFound);
     }
 };
 
-/** @brief Verifies exception thrown for malformed rotor configuration. */
+/** @brief Verifies error returned for malformed rotor configuration. */
 TEST_F(EnigmaConfigLoaderTests, LoadMalformedRotor) {
     MalformedAssetProvider provider;
-    EXPECT_THROW({ EnigmaConfigLoader::loadRotor(provider, FileName("bad_rotor.toml")); }, std::exception);
+    auto result = EnigmaConfigLoader::loadRotor(provider, FileName("bad_rotor.toml"));
+    EXPECT_FALSE(result.has_value());
+    EXPECT_EQ(result.error(), enigma::EnigmaError::ConfigFieldMissing);
 }
 
-/** @brief Verifies exception thrown when loading wrong component type. */
-TEST_F(EnigmaConfigLoaderTests, LoadWrongComponentType) {
+/** @brief Verifies error returned when rotor configuration is missing required fields. */
+TEST_F(EnigmaConfigLoaderTests, LoadMissingRotorField) {
     MalformedAssetProvider provider;
-    EXPECT_THROW({ EnigmaConfigLoader::loadRotor(provider, FileName("wrong_type.toml")); }, std::exception);
+    auto result = EnigmaConfigLoader::loadRotor(provider, FileName("wrong_type.toml"));
+    EXPECT_FALSE(result.has_value());
+    EXPECT_EQ(result.error(), enigma::EnigmaError::ConfigFieldMissing);
 }
 
-/** @brief Verifies exception thrown for inconsistent configuration. */
+/** @brief Verifies error returned for inconsistent configuration. */
 TEST_F(EnigmaConfigLoaderTests, LoadInconsistentConfig) {
     MalformedAssetProvider provider;
-    EXPECT_THROW({ EnigmaConfigLoader::load(provider, FileName("inconsistent_count.toml")); }, std::exception);
+    auto result = EnigmaConfigLoader::load(provider, FileName("inconsistent_count.toml"));
+    EXPECT_FALSE(result.has_value());
+    EXPECT_EQ(result.error(), enigma::EnigmaError::ConfigCountMismatch);
 }

--- a/tests/EnigmaMachine/TestEnigmaConfigLoader.cpp
+++ b/tests/EnigmaMachine/TestEnigmaConfigLoader.cpp
@@ -78,6 +78,47 @@ public:
             return std::string(
                 "[rotors]\nRotorCount = 3\nRotorPositions = [0, 0, 0]\nRotorFiles = [\"R1.toml\", \"R2.toml\"]");
         }
+        if (assetName == "wrong_size.toml") {
+            return std::string(
+                "[rotor]\nnotchPosition = 0\ntype = \"rotor\"\nsize = 24\nforward = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, "
+                "11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25]");
+        }
+        if (assetName == "R1.toml") {
+            return std::string(
+                "[rotor]\nnotchPosition = 0\ntype = \"rotor\"\nsize = 26\nforward = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, "
+                "11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25]");
+        }
+        if (assetName == "Reflector.toml") {
+            return std::string(
+                "[reflector]\ntype = \"reflector\"\nsize = 26\nmap = [24, 17, 20, 7, 16, 22, 15, 23, 18, 25, "
+                "8, 13, 1, 11, 4, 2, 19, 12, 14, 21, 6, 9, 3, 0, 10, 5]");
+        }
+        if (assetName == "too_many_plugs.toml") {
+            return std::string(
+                "[rotors]\nRotorCount = 1\nRotorPositions = [0]\nRotorFiles = [\"valid_rotor.toml\"]\n"
+                "ReflectorFile = \"valid_reflector.toml\"\n"
+                "[plugboard]\nPlugCount = 15\nPlugBoardPairs = [{from = 0, to = 1}, {from = 2, to = 3}, {from = 4, to "
+                "= 5}, "
+                "{from = 6, to = 7}, {from = 8, to = 9}, {from = 10, to = 11}, {from = 12, to = 13}, "
+                "{from = 14, to = 15}, {from = 16, to = 17}, {from = 18, to = 19}, {from = 20, to = 21}, "
+                "{from = 22, to = 23}, {from = 24, to = 25}, {from = 3, to = 0}, {from = 5, to = 2}]");
+        }
+        if (assetName == "mismatched_plug_count.toml") {
+            return std::string(
+                "[rotors]\nRotorCount = 1\nRotorPositions = [0]\nRotorFiles = [\"valid_rotor.toml\"]\n"
+                "ReflectorFile = \"valid_reflector.toml\"\n"
+                "[plugboard]\nPlugCount = 3\nPlugBoardPairs = [{from = 0, to = 1}, {from = 2, to = 3}]");
+        }
+        if (assetName == "valid_rotor.toml") {
+            return std::string(
+                "[rotor]\nnotchPosition = 0\ntype = \"rotor\"\nsize = 26\nforward = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, "
+                "11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25]");
+        }
+        if (assetName == "valid_reflector.toml") {
+            return std::string(
+                "[reflector]\ntype = \"reflector\"\nsize = 26\nmap = [24, 17, 20, 7, 16, 22, 15, 23, 18, 25, "
+                "8, 13, 1, 11, 4, 2, 19, 12, 14, 21, 6, 9, 3, 0, 10, 5]");
+        }
         return nonstd::make_unexpected(enigma::EnigmaError::FileNotFound);
     }
 };
@@ -104,4 +145,28 @@ TEST_F(EnigmaConfigLoaderTests, LoadInconsistentConfig) {
     auto result = EnigmaConfigLoader::load(provider, FileName("inconsistent_count.toml"));
     EXPECT_FALSE(result.has_value());
     EXPECT_EQ(result.error(), enigma::EnigmaError::ConfigCountMismatch);
+}
+
+/** @brief Verifies error returned when rotor has wrong size. */
+TEST_F(EnigmaConfigLoaderTests, LoadRotorWrongSize) {
+    MalformedAssetProvider provider;
+    auto result = EnigmaConfigLoader::loadRotor(provider, FileName("wrong_size.toml"));
+    EXPECT_FALSE(result.has_value());
+    EXPECT_EQ(result.error(), enigma::EnigmaError::ConfigFieldMissing);
+}
+
+/** @brief Verifies error returned when plugboard exceeds maximum pairs. */
+TEST_F(EnigmaConfigLoaderTests, LoadConfigTooManyPlugs) {
+    MalformedAssetProvider provider;
+    auto result = EnigmaConfigLoader::load(provider, FileName("too_many_plugs.toml"));
+    EXPECT_FALSE(result.has_value());
+    EXPECT_EQ(result.error(), enigma::EnigmaError::ConfigFieldMissing);
+}
+
+/** @brief Verifies error returned when plugboard count doesn't match array size. */
+TEST_F(EnigmaConfigLoaderTests, LoadConfigMismatchedPlugCount) {
+    MalformedAssetProvider provider;
+    auto result = EnigmaConfigLoader::load(provider, FileName("mismatched_plug_count.toml"));
+    EXPECT_FALSE(result.has_value());
+    EXPECT_EQ(result.error(), enigma::EnigmaError::ConfigFieldMissing);
 }

--- a/tests/EnigmaMachine/TestEnigmaMachine.cpp
+++ b/tests/EnigmaMachine/TestEnigmaMachine.cpp
@@ -2,8 +2,11 @@
 #include <string>
 #include <vector>
 #include "EnigmaConfig.hpp"
+#include "EnigmaError.hpp"
 #include "EnigmaMachine.hpp"
+#include "EnigmaMachineConfig.hpp"
 #include "FileAssetProvider.hpp"
+#include "IAssetProvider.hpp"
 
 class EnigmaMachineTests : public ::testing::Test {
 protected:
@@ -325,4 +328,51 @@ TEST_F(EnigmaMachineTests, Destructor) {
     EnigmaMachine* machine = new EnigmaMachine();
     machine->keyTransform(0);
     EXPECT_NO_THROW(delete machine);
+}
+
+/** @brief Mock provider that always returns errors for testing error paths. */
+class FailingAssetProvider : public IAssetProvider {
+public:
+    enigma::Result<std::string> loadAsset(std::string_view assetName) const override {
+        return nonstd::make_unexpected(enigma::EnigmaError::FileNotFound);
+    }
+};
+
+/** @brief Verifies EnigmaMachine constructor throws when config loading fails. */
+TEST_F(EnigmaMachineTests, ConstructorThrowsOnConfigLoadFailure) {
+    FailingAssetProvider provider;
+    EXPECT_THROW(EnigmaMachine machine(provider, "nonexistent.toml", "", nullptr), std::runtime_error);
+}
+
+/** @brief Verifies EnigmaMachine constructor throws when rotor loading fails. */
+TEST_F(EnigmaMachineTests, ConstructorThrowsOnRotorLoadFailure) {
+    FailingAssetProvider provider;
+    EXPECT_THROW(EnigmaMachine machine(provider, "assets/EnigmaMachineConfig1.toml", "", nullptr), std::runtime_error);
+}
+
+/** @brief Verifies move assignment operator works correctly. */
+TEST_F(EnigmaMachineTests, MoveAssignmentOperator) {
+    EnigmaMachine machine1(configPath, enigma::assetsDir);
+    EnigmaMachine machine2;
+    machine2 = std::move(machine1);
+    EXPECT_NO_THROW(machine2.keyTransform(0));
+}
+
+/** @brief Verifies setLogger updates the logger correctly. */
+TEST_F(EnigmaMachineTests, SetLogger) {
+    EnigmaMachine machine;
+    EXPECT_NO_THROW(machine.setLogger(nullptr));
+}
+
+/** @brief Verifies observer registration and removal work correctly. */
+TEST_F(EnigmaMachineTests, ObserverRegistration) {
+    EnigmaMachine machine;
+    class DummyObserver : public IEnigmaObserver {
+    public:
+        void onRotorStepped(int, AlphabetIndex) override {}
+        void onCharEncrypted(char, char) override {}
+    };
+    DummyObserver observer;
+    EXPECT_NO_THROW(machine.registerObserver(&observer));
+    EXPECT_NO_THROW(machine.removeObserver(&observer));
 }

--- a/tests/EnigmaMachine/TestPODData.cpp
+++ b/tests/EnigmaMachine/TestPODData.cpp
@@ -80,9 +80,10 @@ TEST_F(EnigmaDataTests, PlugBoardPairDataFieldNamesAlign) {
 
 /** @brief Verifies EnigmaMachineConfig.toData() produces a correctly populated EnigmaMachineData. */
 TEST_F(EnigmaDataTests, toDataPopulatesAllFields) {
-    EnigmaMachineConfig config;
     FileAssetProvider provider;
-    config = EnigmaConfigLoader::load(provider, FileName(configPath), AssetPath(enigma::assetsDir));
+    auto configResult = EnigmaConfigLoader::load(provider, FileName(configPath), AssetPath(enigma::assetsDir));
+    ASSERT_TRUE(configResult.has_value());
+    EnigmaMachineConfig config = *configResult;
 
     enigma::EnigmaMachineData data = config.toData();
 
@@ -98,9 +99,10 @@ TEST_F(EnigmaDataTests, toDataPopulatesAllFields) {
 
 /** @brief Verifies EnigmaMachine can be constructed from EnigmaMachineData and encrypts correctly. */
 TEST_F(EnigmaDataTests, PODConstructorEncryption) {
-    EnigmaMachineConfig config;
     FileAssetProvider provider;
-    config = EnigmaConfigLoader::load(provider, FileName(configPath), AssetPath(enigma::assetsDir));
+    auto configResult = EnigmaConfigLoader::load(provider, FileName(configPath), AssetPath(enigma::assetsDir));
+    ASSERT_TRUE(configResult.has_value());
+    EnigmaMachineConfig config = *configResult;
 
     enigma::EnigmaMachineData data = config.toData();
 
@@ -117,9 +119,10 @@ TEST_F(EnigmaDataTests, PODConstructorEncryption) {
 /** @brief Verifies POD roundtrip: encrypt via file -> toData() -> same result. */
 TEST_F(EnigmaDataTests, toDataRoundtrip) {
     EnigmaMachine machine1(configPath, enigma::assetsDir);
-    EnigmaMachineConfig config;
     FileAssetProvider provider;
-    config = EnigmaConfigLoader::load(provider, FileName(configPath), AssetPath(enigma::assetsDir));
+    auto configResult = EnigmaConfigLoader::load(provider, FileName(configPath), AssetPath(enigma::assetsDir));
+    ASSERT_TRUE(configResult.has_value());
+    EnigmaMachineConfig config = *configResult;
     enigma::EnigmaMachineData data = config.toData();
     EnigmaMachine machine2(data);
 
@@ -132,9 +135,10 @@ TEST_F(EnigmaDataTests, toDataRoundtrip) {
 
 /** @brief Verifies POD-initialized machine exhibits reciprocal encryption. */
 TEST_F(EnigmaDataTests, PODReciprocity) {
-    EnigmaMachineConfig config;
     FileAssetProvider provider;
-    config = EnigmaConfigLoader::load(provider, FileName(configPath), AssetPath(enigma::assetsDir));
+    auto configResult = EnigmaConfigLoader::load(provider, FileName(configPath), AssetPath(enigma::assetsDir));
+    ASSERT_TRUE(configResult.has_value());
+    EnigmaMachineConfig config = *configResult;
     enigma::EnigmaMachineData data = config.toData();
 
     const std::string plain = "HELLOWORLD";
@@ -207,9 +211,10 @@ TEST_F(EnigmaDataTests, PODConstructorFullConfig) {
 
 /** @brief Verifies toData() and POD constructor preserve rotor stepping behavior. */
 TEST_F(EnigmaDataTests, PODPreservesRotorStepping) {
-    EnigmaMachineConfig config;
     FileAssetProvider provider;
-    config = EnigmaConfigLoader::load(provider, FileName(configPath), AssetPath(enigma::assetsDir));
+    auto configResult = EnigmaConfigLoader::load(provider, FileName(configPath), AssetPath(enigma::assetsDir));
+    ASSERT_TRUE(configResult.has_value());
+    EnigmaMachineConfig config = *configResult;
     enigma::EnigmaMachineData data = config.toData();
 
     EnigmaMachine machine(data);

--- a/tests/RotorBox/TestReflector.cpp
+++ b/tests/RotorBox/TestReflector.cpp
@@ -12,7 +12,9 @@ protected:
 
     void SetUp() override {
         FileAssetProvider provider;
-        config = EnigmaConfigLoader::loadReflector(provider, FileName(configPath));
+        auto result = EnigmaConfigLoader::loadReflector(provider, FileName(configPath));
+        ASSERT_TRUE(result.has_value());
+        config = *result;
     }
 };
 

--- a/tests/RotorBox/TestReflectorProperties.cpp
+++ b/tests/RotorBox/TestReflectorProperties.cpp
@@ -13,7 +13,11 @@ protected:
 
     void SetUp() override {
         FileAssetProvider provider;
-        config = EnigmaConfigLoader::loadReflector(provider, FileName(configPath));
+        auto result = EnigmaConfigLoader::loadReflector(provider, FileName(configPath));
+        RC_ASSERT(result.has_value());
+        if (result) {
+            config = *result;
+        }
     }
 };
 

--- a/tests/RotorBox/TestRotor.cpp
+++ b/tests/RotorBox/TestRotor.cpp
@@ -12,7 +12,9 @@ protected:
 
     void SetUp() override {
         FileAssetProvider provider;
-        config = EnigmaConfigLoader::loadRotor(provider, EnigmaConfigLoader::FileName(configPath));
+        auto result = EnigmaConfigLoader::loadRotor(provider, EnigmaConfigLoader::FileName(configPath));
+        ASSERT_TRUE(result.has_value());
+        config = *result;
     }
 };
 

--- a/tests/RotorBox/TestRotorBox.cpp
+++ b/tests/RotorBox/TestRotorBox.cpp
@@ -21,10 +21,18 @@ protected:
 
     void SetUp() override {
         FileAssetProvider provider;
-        rotors.push_back(EnigmaConfigLoader::loadRotor(provider, rotorFiles[0]));
-        rotors.push_back(EnigmaConfigLoader::loadRotor(provider, rotorFiles[1]));
-        rotors.push_back(EnigmaConfigLoader::loadRotor(provider, rotorFiles[2]));
-        reflector = EnigmaConfigLoader::loadReflector(provider, rotorFiles[3]);
+        auto r1 = EnigmaConfigLoader::loadRotor(provider, rotorFiles[0]);
+        auto r2 = EnigmaConfigLoader::loadRotor(provider, rotorFiles[1]);
+        auto r3 = EnigmaConfigLoader::loadRotor(provider, rotorFiles[2]);
+        auto refl = EnigmaConfigLoader::loadReflector(provider, rotorFiles[3]);
+        ASSERT_TRUE(r1.has_value());
+        ASSERT_TRUE(r2.has_value());
+        ASSERT_TRUE(r3.has_value());
+        ASSERT_TRUE(refl.has_value());
+        rotors.push_back(*r1);
+        rotors.push_back(*r2);
+        rotors.push_back(*r3);
+        reflector = *refl;
     }
 };
 

--- a/tests/RotorBox/TestRotorBoxProperties.cpp
+++ b/tests/RotorBox/TestRotorBoxProperties.cpp
@@ -21,10 +21,26 @@ protected:
 
     void SetUp() override {
         FileAssetProvider provider;
-        rotors.push_back(EnigmaConfigLoader::loadRotor(provider, rotorFiles[0]));
-        rotors.push_back(EnigmaConfigLoader::loadRotor(provider, rotorFiles[1]));
-        rotors.push_back(EnigmaConfigLoader::loadRotor(provider, rotorFiles[2]));
-        reflector = EnigmaConfigLoader::loadReflector(provider, rotorFiles[3]);
+        auto r1 = EnigmaConfigLoader::loadRotor(provider, rotorFiles[0]);
+        auto r2 = EnigmaConfigLoader::loadRotor(provider, rotorFiles[1]);
+        auto r3 = EnigmaConfigLoader::loadRotor(provider, rotorFiles[2]);
+        auto refl = EnigmaConfigLoader::loadReflector(provider, rotorFiles[3]);
+        RC_ASSERT(r1.has_value());
+        RC_ASSERT(r2.has_value());
+        RC_ASSERT(r3.has_value());
+        RC_ASSERT(refl.has_value());
+        if (r1) {
+            rotors.push_back(*r1);
+        }
+        if (r2) {
+            rotors.push_back(*r2);
+        }
+        if (r3) {
+            rotors.push_back(*r3);
+        }
+        if (refl) {
+            reflector = *refl;
+        }
     }
 };
 

--- a/tests/RotorBox/TestRotorProperties.cpp
+++ b/tests/RotorBox/TestRotorProperties.cpp
@@ -15,7 +15,11 @@ protected:
 
     void SetUp() override {
         FileAssetProvider provider;
-        config = EnigmaConfigLoader::loadRotor(provider, FileName(configPath));
+        auto result = EnigmaConfigLoader::loadRotor(provider, FileName(configPath));
+        RC_ASSERT(result.has_value());
+        if (result) {
+            config = *result;
+        }
     }
 };
 

--- a/tests/RotorBox/TestTransformer.cpp
+++ b/tests/RotorBox/TestTransformer.cpp
@@ -12,6 +12,16 @@ public:
     int transformForward(int position) const override { return position; }
     int transformReverse(int position) const override { return position; }
     int rotate() override { return 0; }
+
+    void testSetTransformValue(int row, int col, AlphabetIndex value) { setTransformValue(row, col, value); }
+    AlphabetIndex testGetTransformValue(int row, int col) const { return getTransformValue(row, col); }
+    void testFillTransformRow(int row, AlphabetIndex value) { fillTransformRow(row, value); }
+    void testCopyTransformRow(int row, const std::array<AlphabetIndex, enigma::TRANSFORMER_SIZE>& values) {
+        copyTransformRow(row, values);
+    }
+    const std::array<AlphabetIndex, enigma::TRANSFORMER_SIZE>& testGetTransformRow(int row) const {
+        return getTransformRow(row);
+    }
 };
 
 /** @brief Verifies Transformer base class default initialization. */
@@ -24,4 +34,48 @@ TEST(TransformerTests, DefaultInitialization) {
 TEST(TransformerTests, LUTSize) {
     ConcreteTransformer transformer;
     EXPECT_EQ(transformer.sizeOfLookupTable(), 52);
+}
+
+/** @brief Verifies setTransformValue and getTransformValue work correctly. */
+TEST(TransformerTests, SetAndGetTransformValue) {
+    ConcreteTransformer transformer;
+    transformer.testSetTransformValue(0, 5, 10);
+    EXPECT_EQ(transformer.testGetTransformValue(0, 5), 10);
+    transformer.testSetTransformValue(1, 15, 20);
+    EXPECT_EQ(transformer.testGetTransformValue(1, 15), 20);
+}
+
+/** @brief Verifies fillTransformRow fills entire row with specified value. */
+TEST(TransformerTests, FillTransformRow) {
+    ConcreteTransformer transformer;
+    transformer.testFillTransformRow(0, 99);
+    for (int i = 0; i < enigma::TRANSFORMER_SIZE; ++i) {
+        EXPECT_EQ(transformer.testGetTransformValue(0, i), 99);
+    }
+}
+
+/** @brief Verifies copyTransformRow copies array values correctly. */
+TEST(TransformerTests, CopyTransformRow) {
+    ConcreteTransformer transformer;
+    std::array<AlphabetIndex, enigma::TRANSFORMER_SIZE> values;
+    for (int i = 0; i < enigma::TRANSFORMER_SIZE; ++i) {
+        values[i] = static_cast<AlphabetIndex>(i * 2);
+    }
+    transformer.testCopyTransformRow(1, values);
+    for (int i = 0; i < enigma::TRANSFORMER_SIZE; ++i) {
+        EXPECT_EQ(transformer.testGetTransformValue(1, i), i * 2);
+    }
+}
+
+/** @brief Verifies getTransformRow returns correct row reference. */
+TEST(TransformerTests, GetTransformRow) {
+    ConcreteTransformer transformer;
+    std::array<AlphabetIndex, enigma::TRANSFORMER_SIZE> values;
+    for (int i = 0; i < enigma::TRANSFORMER_SIZE; ++i) {
+        values[i] = static_cast<AlphabetIndex>(i);
+    }
+    transformer.testCopyTransformRow(0, values);
+    const auto& row = transformer.testGetTransformRow(0);
+    EXPECT_EQ(row[0], 0);
+    EXPECT_EQ(row[25], 25);
 }


### PR DESCRIPTION
## Description

Replace C++ exceptions with std::expected (via martinmoene/expected-lite) for IAssetProvider and EnigmaConfigLoader public interfaces. EnigmaMachine constructors retain exceptions as a temporary bridge (Option A) until Static Factories (Task 2.2).

Breaking Change: IAssetProvider::loadAsset() and all EnigmaConfigLoader static methods now return enigma::Result<T> instead of throwing. Callers must check result.has_value() before accessing the value.

Core Changes
- Add external/expected-lite as git submodule (martinmoene/expected-lite v0.10.0)
- Add include/EnigmaError.hpp: enum class EnigmaError (12 codes) + Result<T> alias
- IAssetProvider::loadAsset() -> enigma::Result<std::string>
- EnigmaConfigLoader::load/loadRotor/loadReflector() -> enigma::Result<T>
- FileAssetProvider: throw -> unexpected(EnigmaError::FileNotFound)
- EnigmaConfigLoader: all throw sites -> return unexpected(code)
- validateTransformerConfig: split catch (out_of_range -> ConfigFieldMissing, general exception -> ConfigCountMismatch), removed dead fileName param
- EnigmaMachine constructors: log error via ILogger, then throw std::runtime_error

New Tests
- 11 new tests across 9 files verifying Result<T> behavior
- 2 new mock providers (MockAssetProvider, MalformedAssetProvider)
- LoadMalformedRotor: 25-element forward array triggers ConfigFieldMissing

Bug Fixes from Code Review
- class_diagram.puml: add ConfigFieldMissing to EnigmaError enum
- TestEnigmaConfigLoader: fix LoadMalformedRotor mock data and assertion
- Property test SetUps: add safe dereference guard after RC_ASSERT

Documentation
- ADR 007: document expected-lite dependency, EnigmaError enum, Result<T>, Option A bridge, error mapping table, CMake changes
- ADR 003: status -> "Implemented by ADR 007"
- class_diagram.puml: update IAssetProvider/FileAssetProvider signatures, EnigmaConfigLoader returns, add EnigmaError enum, add Result relationships
- config_loading_sequence.puml: rewrite to show Result<string> from loadAsset, nested alt/else fragments for error propagation

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Tools update

## How Has This Been Validated?

Run test locally.

**Test Configuration**:
* Compiler/Toolchain: g++, ctests, cmake
* OS/Platform: Linux

## Checklist:

- [x] My code is documented with doxygen comments
- [x] I have made corresponding changes to the documentation
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Additional Information

Code Coverage lower than the goal, it should be fix later.

## Contributors

List of contributors to this pull request:
- @alvarocleite 
